### PR TITLE
Adding a fallbackLocale to RRule::humanReadable()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
+- Support for fallback locale when using `RRule::humanReadable()` [#11](https://github.com/rlanvin/php-rrule/pull/11)
 - Dutch translation (NL) [#9](https://github.com/rlanvin/php-rrule/pull/9)
+
+### Fixed
+
+- Fixed fatal error Locale class not found when intl extension is not loaded [#11](https://github.com/rlanvin/php-rrule/pull/11)
 
 ## [1.1.0] - 2016-03-30
 


### PR DESCRIPTION
It's worth to note that the test is quite worthless if `Intl` is loaded or the `setlocale()` returns actual usable results.

Also `setlocale(LC_ALL, 0)` returns `C/en_US.utf-8/C/C/C/C` for me, and I noticed that it's different per OS and server configurations. So I opted to extract the first matching locale from that string. Do you think that's ok?