### PR TITLE
Change values of FREQ when get the RFC string to match the convention

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -528,7 +528,7 @@ class RRule implements RRuleInterface
 	 * Magic string converter.
 	 *
 	 * @see RRule::rfcString()
-	 * @return a rfc string
+	 * @return string a rfc string
 	 */
 	public function __toString()
 	{
@@ -602,6 +602,12 @@ class RRule implements RRuleInterface
 					$parts[] = 'UNTIL='.$tmp->format('Ymd\THis\Z');
 				}
 				continue;
+			}
+			if ( $key === 'FREQ' && $value && !array_key_exists($value, static::$frequencies) ) {
+				$frequencyKey = array_search($value, static::$frequencies);
+				if ($frequencyKey !== false) {
+					$value = $frequencyKey;
+				}
 			}
 			if ( $value ) {
 				if ( is_array($value) ) {

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -604,9 +604,9 @@ class RRule implements RRuleInterface
 				continue;
 			}
 			if ( $key === 'FREQ' && $value && !array_key_exists($value, static::$frequencies) ) {
-				$frequencyKey = array_search($value, static::$frequencies);
-				if ($frequencyKey !== false) {
-					$value = $frequencyKey;
+				$frequency_key = array_search($value, static::$frequencies);
+				if ($frequency_key !== false) {
+					$value = $frequency_key;
 				}
 			}
 			if ( $value ) {

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -1845,6 +1845,70 @@ class RRuleTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected_str, $rule->rfcString(false));
 	}
 
+	public function rfcStringsGenerated()
+	{
+		return array(
+			array(
+				array(
+					'FREQ' => RRule::YEARLY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=YEARLY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::MONTHLY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=MONTHLY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::WEEKLY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=WEEKLY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::DAILY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=DAILY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::HOURLY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=HOURLY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::MINUTELY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=MINUTELY"
+			),
+			array(
+				array(
+					'FREQ' => RRule::SECONDLY,
+					'DTSTART' => date_create('2015-07-01 09:00:00', new DateTimeZone('Australia/Sydney'))
+				),
+				"DTSTART;TZID=Australia/Sydney:20150701T090000\nRRULE:FREQ=SECONDLY"
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider rfcStringsGenerated
+	 */
+	public function testRfcStringsGenerated($params, $expected_str)
+	{
+		$rule = new RRule($params);
+		$this->assertEquals($expected_str, $rule->rfcString());
+	}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Timezone
 


### PR DESCRIPTION
Hi,

In the RFC convention the frequency is a string ("WEEKLY", "YEARLY" ...) not a number when we want to get the RRule string : https://tools.ietf.org/html/rfc5545#page-39

This pull request fix this example : 

```php
$rrule = new RRule([
    'FREQ' => 'MONTHLY',
    'INTERVAL' => 1,
    'DTSTART' => '2015-06-01',
    'COUNT' => 6
]);
$copyRrule = new RRule($rrule->rfcString()); // FREQ need to be 'MONTHLY' not 2
```