### PR TITLE
Add getRule() method to return original rule array

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2574,4 +2574,8 @@ class RRule implements RRuleInterface
 		$str = implode('',$parts);
 		return $str;
 	}
+
+	public function getRule() {
+		return $this->rule;
+	}
 }


### PR DESCRIPTION
I found this to be a useful addition for creating HTML forms with multiple inputs/selectors for saving/loading data

It means I don't have to do something like this to get a particular part of the rule (which might not exist)

    foreach (explode(";", $rfc_rrule_string) as $part) {
      $key = explode("=", $part)[0];
      $value = explode("=", $part)[1];
      if ($key == $field_name) {
        //set field to $value
      }
    }

Instead I can just do

    use RRule\RRule;
    $rrule = new RRule($rfc_rrule_string);
    $myField = $rrule->getRule()[$field_name];

