### PR TITLE
fixed Warning in RRule->humanReadable()

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2337,7 +2337,8 @@ class RRule implements RRuleInterface
 		if ( $opt['use_intl'] ) {
 			$default_opt['locale'] = \Locale::getDefault();
 		} else {
-			$default_opt['locale'] = setlocale(LC_MESSAGES, 0);
+			$category = defined('LC_MESSAGES') ? LC_MESSAGES : LC_ALL;
+			$default_opt['locale'] = setlocale($category, 0);
 			if ( $default_opt['locale'] == 'C' ) {
 				$default_opt['locale'] = 'en';
 			}

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2337,8 +2337,7 @@ class RRule implements RRuleInterface
 		if ( $opt['use_intl'] ) {
 			$default_opt['locale'] = \Locale::getDefault();
 		} else {
-			$category = defined('LC_MESSAGES') ? LC_MESSAGES : LC_ALL;
-			$default_opt['locale'] = setlocale($category, 0);
+			$default_opt['locale'] = setlocale(LC_ALL, 0);
 			if ( $default_opt['locale'] == 'C' ) {
 				$default_opt['locale'] = 'en';
 			}


### PR DESCRIPTION
[ Warning: Use of undefined constant LC_MESSAGES - assumed 'LC_MESSAGES' (this will throw an Error in a future version of PHP) in ...vendor\rlanvin\php-rrule\src\RRule.php on line 2340 ]

LC_MESSAGES is not available. It is available only if PHP was compiled with libintl.
use LC_ALL instead.

Thank you for this awesome project! :)
