### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
-dist: precise
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 install:
-  - composer install
-  - composer require --dev phpunit/phpunit "<6"
+  - composer install -n
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,12 @@
             "RRule\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "RRule\\Tests\\": "tests/"
+        }
+    },
     "require-dev": {
-        "phpunit/phpunit": "<6"
+        "phpunit/phpunit": "^4.8|^5.5|^6.5"
     }
 }

--- a/tests/RfcParserTest.php
+++ b/tests/RfcParserTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use RRule\RfcParser;
+namespace RRule\Tests;
 
-class RfcParserTest extends PHPUnit_Framework_TestCase
+use RRule\RfcParser;
+use PHPUnit\Framework\TestCase;
+
+class RfcParserTest extends TestCase
 {
 	public function rfcLines()
 	{

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,11 @@
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
+
+if (class_exists('PHPUnit_Framework_Error_Notice')) {
+    class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
+}
+
+// make sure that the tests are run in the same timezone everywhere
+// Europe/Helsinki has DST
+date_default_timezone_set('Europe/Helsinki');


### PR DESCRIPTION
# Changed log

- Set the different PHPUnit version for the different PHP versions tests.
- Using ```PHPUnit_Framework_Error_Notice``` alias to be compatible with different PHPUnit versions.
- Using ```expectedException``` annotation to be compatible with different PHP
Unit versions.
- The normal and unexpected exceptions tests should be separated.