### PR TITLE
VALUE is a valid param of EXDATE

### DIFF
--- a/src/RfcParser.php
+++ b/src/RfcParser.php
@@ -278,6 +278,9 @@ class RfcParser
 		$tz = null;
 		foreach ( $property['params'] as $name => $value ) {
 			switch ( strtoupper($name) ) {
+				case 'VALUE':
+					// Ignore optional words
+					break;
 				case 'TZID':
 					$tz = new \DateTimeZone($value);
 				break;

--- a/tests/RSetTest.php
+++ b/tests/RSetTest.php
@@ -526,8 +526,8 @@ class RSetTest extends TestCase
 				RRULE:FREQ=MONTHLY;WKST=MO;BYDAY=-1WE;UNTIL=20180131T200000Z
 				DTSTART:20171129T200000Z",
 				array(
-					date_create('2017-11-29 20:00:00', new \DateTimeZone('Z')),
-					date_create('2018-01-31 20:00:00', new \DateTimeZone('Z'))
+					date_create('2017-11-29 20:00:00', new \DateTimeZone('GMT')),
+					date_create('2018-01-31 20:00:00', new \DateTimeZone('GMT'))
 				)
 			),
 		);

--- a/tests/RSetTest.php
+++ b/tests/RSetTest.php
@@ -520,7 +520,16 @@ class RSetTest extends TestCase
 					date_create('1997-09-02 09:00:00', new \DateTimeZone('America/New_York')),
 					date_create('1997-09-04 09:00:00', new \DateTimeZone('America/New_York'))
 				)
-			)
+			),
+			array(
+				"EXDATE;VALUE=DATE-TIME:20171227T200000Z
+				RRULE:FREQ=MONTHLY;WKST=MO;BYDAY=-1WE;UNTIL=20180131T200000Z
+				DTSTART:20171129T200000Z",
+				array(
+					date_create('2017-11-29 20:00:00', new \DateTimeZone('Z')),
+					date_create('2018-01-31 20:00:00', new \DateTimeZone('Z'))
+				)
+			),
 		);
 	}
 


### PR DESCRIPTION
EXDATE rule like 'EXDATE;VALUE=DATE-TIME:20171227T200000Z'
Are valid [according to the rfc](https://tools.ietf.org/html/rfc5545#section-3.8.5.1) but rejected because VALUE param is not recognized.