### PR TITLE
Add remove/clear functions for ExDates and RDates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 test.php
 composer.lock
+.idea

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2061,6 +2061,9 @@ class RRule implements RRuleInterface
 	 * Parse a locale and returns a list of files to load.
 	 * For example "fr_FR" will produce "fr" and "fr_FR"
 	 *
+	 * @param $locale
+	 * @param null $use_intl
+	 *
 	 * @return array
 	 */
 	static protected function i18nFilesToLoad($locale, $use_intl = null)

--- a/src/RSet.php
+++ b/src/RSet.php
@@ -258,6 +258,47 @@ class RSet implements RRuleInterface
 	}
 
 	/**
+	 * Remove an EXDATE
+	 *
+	 * @param mixed $date a valid date representation or a \DateTime object
+	 * @return $this
+	 */
+	public function removeExDate($date)
+	{
+		try {
+			$dateToRemove = RRule::parseDate($date);
+			$index = array_search($dateToRemove, $this->exdates);
+
+			if ( $index !== false ) {
+				unset($this->exdates[$index]);
+				$this->exdates = array_values($this->exdates);
+			}
+
+		} catch (\Exception $e) {
+			throw new \InvalidArgumentException(
+				'Failed to parse EXDATE - it must be a valid date, timestamp or \DateTime object'
+			);
+		}
+
+		$this->clearCache();
+
+		return $this;
+	}
+
+	/**
+	 * Removes all EXDATEs
+	 *
+	 * @return $this
+	 */
+	public function clearExDates()
+	{
+		$this->exdates = [];
+		$this->clearCache();
+
+		return $this;
+	}
+
+	/**
 	 * Return the EXDATE(s) contained in this set
 	 *
 	 * @todo check if a deep copy is needed.

--- a/src/RSet.php
+++ b/src/RSet.php
@@ -224,6 +224,46 @@ class RSet implements RRuleInterface
 	}
 
 	/**
+	 * Remove an RDATE
+	 *
+	 * @param mixed $date a valid date representation or a \DateTime object
+	 * @return $this
+	 */
+	public function removeDate($date)
+	{
+		try {
+			$date_to_remove = RRule::parseDate($date);
+			$index = array_search($date_to_remove, $this->rdates);
+
+			if ( $index !== false ) {
+				unset($this->rdates[$index]);
+				$this->rdates = array_values($this->rdates);
+			}
+		} catch (\Exception $e) {
+			throw new \InvalidArgumentException(
+				'Failed to parse RDATE - it must be a valid date, timestamp or \DateTime object'
+			);
+		}
+
+		$this->clearCache();
+
+		return $this;
+	}
+
+	/**
+	 * Remove all RDATEs
+	 *
+	 * @return $this
+	 */
+	public function clearDates()
+	{
+		$this->rdates = [];
+		$this->clearCache();
+
+		return $this;
+	}
+
+	/**
 	 * Return the RDATE(s) contained in this set
 	 *
 	 * @todo check if a deep copy is needed.
@@ -266,14 +306,13 @@ class RSet implements RRuleInterface
 	public function removeExDate($date)
 	{
 		try {
-			$dateToRemove = RRule::parseDate($date);
-			$index = array_search($dateToRemove, $this->exdates);
+			$date_to_remove = RRule::parseDate($date);
+			$index = array_search($date_to_remove, $this->exdates);
 
 			if ( $index !== false ) {
 				unset($this->exdates[$index]);
 				$this->exdates = array_values($this->exdates);
 			}
-
 		} catch (\Exception $e) {
 			throw new \InvalidArgumentException(
 				'Failed to parse EXDATE - it must be a valid date, timestamp or \DateTime object'

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -2771,6 +2771,7 @@ class RRuleTest extends TestCase
 				$method->invokeArgs(null, array($locale, false));
 				$this->fail('Expected InvalidArgumentException not thrown (files was '.json_encode($files).')');
 			} catch (\InvalidArgumentException $e) {
+				$this->assertStringStartsWith("The locale option does not look like a valid locale:", $e->getMessage());
 			}
 		}
 		else {

--- a/tests/RSetTest.php
+++ b/tests/RSetTest.php
@@ -87,6 +87,55 @@ class RSetTest extends TestCase
 		$this->assertFalse($rset->occursAt('1997-09-03 09:00'));
 	}
 
+	public function testRemoveDateFromRSet()
+	{
+		$rset = new RSet();
+		$rset->addRRule(array(
+			'FREQ' => 'YEARLY',
+			'COUNT' => 1,
+			'BYDAY' => 'TU',
+			'DTSTART' => date_create('1997-09-02 09:00')
+		));
+		$rset->addDate(date_create('1997-09-04 09:00'));
+		$rset->addDate(date_create('1997-09-09 09:00'));
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-04 09:00'),
+			date_create('1997-09-09 09:00')
+		), $rset->getOccurrences());
+
+		$rset->removeDate(date_create('1997-09-09 09:00'));
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-04 09:00')
+		), $rset->getOccurrences());
+	}
+
+	public function testClearDatesFromRSet()
+	{
+		$rset = new RSet();
+		$rset->addRRule(array(
+			'FREQ' => 'YEARLY',
+			'COUNT' => 1,
+			'BYDAY' => 'TU',
+			'DTSTART' => date_create('1997-09-02 09:00')
+		));
+		$rset->addDate(date_create('1997-09-04 09:00'));
+		$rset->addDate(date_create('1997-09-09 09:00'));
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-04 09:00'),
+			date_create('1997-09-09 09:00')
+		), $rset->getOccurrences());
+
+		$rset->clearDates();
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+		), $rset->getOccurrences());
+	}
+
 	public function testCombineRRuleAndExRule()
 	{
 		$rset = new RSet();

--- a/tests/RSetTest.php
+++ b/tests/RSetTest.php
@@ -151,9 +151,83 @@ class RSetTest extends TestCase
 		$this->assertFalse($rset->occursAt('1997-09-04 09:00'));
 	}
 
+	public function testRemoveExdDateFromRSet()
+	{
+		$rset = new RSet();
+		$rset->addRRule(array(
+			'FREQ' => 'YEARLY',
+			'COUNT' => 6,
+			'BYDAY' => 'TU, TH',
+			'DTSTART' => date_create('1997-09-02 09:00')
+		));
+
+		$rset->addExdate('1997-09-04 09:00:00');
+		$rset->addExdate('1997-09-11 09:00:00');
+		$rset->addExdate('1997-09-18 09:00:00'); // adding out of order
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-09 09:00'),
+			date_create('1997-09-16 09:00')
+		), $rset->getOccurrences());
+
+		$rset->removeExdate('1997-09-11 09:00:00');
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-09 09:00'),
+			date_create('1997-09-11 09:00'),
+			date_create('1997-09-16 09:00')
+		), $rset->getOccurrences());
+
+		$rset->removeExdate('1997-09-18 09:00:00');
+		$rset->removeExdate('1997-09-04 09:00:00');
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-04 09:00'),
+			date_create('1997-09-09 09:00'),
+			date_create('1997-09-11 09:00'),
+			date_create('1997-09-16 09:00'),
+			date_create('1997-09-18 09:00')
+		), $rset->getOccurrences());
+	}
+
+	public function testClearExDatesFromRSet()
+	{
+		$rset = new RSet();
+		$rset->addRRule(array(
+			'FREQ' => 'YEARLY',
+			'COUNT' => 6,
+			'BYDAY' => 'TU, TH',
+			'DTSTART' => date_create('1997-09-02 09:00')
+		));
+
+		$rset->addExdate('1997-09-04 09:00:00');
+		$rset->addExdate('1997-09-11 09:00:00');
+		$rset->addExdate('1997-09-18 09:00:00'); // adding out of order
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-09 09:00'),
+			date_create('1997-09-16 09:00')
+		), $rset->getOccurrences());
+
+		$rset->clearExDates();
+
+		$this->assertEquals(array(
+			date_create('1997-09-02 09:00'),
+			date_create('1997-09-04 09:00'),
+			date_create('1997-09-09 09:00'),
+			date_create('1997-09-11 09:00'),
+			date_create('1997-09-16 09:00'),
+			date_create('1997-09-18 09:00')
+		), $rset->getOccurrences());
+	}
+
 	public function testCombineEverything()
 	{
-		// TODO
+		$this->markTestIncomplete("TODO!");
 	}
 
 	public function testCombineMultipleTimezones()


### PR DESCRIPTION
- These functions remove one or all exdates/rdates set in an rset.
- When I was poking around I noticed some tests were throwing warnings.
I attempted to clean up the warnings as best I can so that they are more
meaningful. Added an additional assertion on a test that was expecting
errors to be thrown.
- Noticed a missing phpdoc and added it in.
- Added phpstorm dir to .gitignore
- Tried to keep cleanups in one commit, code changes in the others.

I tried to follow the coding standards as best as I could see, however I don't have a copy of the particular set used here. Maybe an .editorconfig file or adding php-cs-fixer and a config to this repo would help in the future?

This solves one part of #65 