### PR TITLE
Fix getOccurrencesAfter when $inclusive is false and $limit is not set

### DIFF
--- a/src/RRuleTrait.php
+++ b/src/RRuleTrait.php
@@ -105,7 +105,9 @@ trait RRuleTrait
 			return $this->getOccurrencesBetween($date, null, $limit);
 		}
 
-		$limit += 1;
+		if ($limit !== null) {
+			$limit += 1;
+		}
 		$occurrences = $this->getOccurrencesBetween($date, null, $limit);
 		return array_slice($occurrences, 1);
 	}

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -1911,6 +1911,7 @@ class RRuleTest extends TestCase
 	public function occurrencesAfter()
 	{
 		return [
+			["DTSTART:20170101\nRRULE:FREQ=DAILY;UNTIL=20170103", '2017-01-01', false, null, [date_create('2017-01-02'), date_create('2017-01-03')]],
 			["DTSTART:20170101\nRRULE:FREQ=DAILY", '2017-02-01', false, 2, [date_create('2017-02-02'),date_create('2017-02-03')]],
 			["DTSTART:20170101\nRRULE:FREQ=DAILY", '2017-02-01', true, 2, [date_create('2017-02-01'),date_create('2017-02-02')]],
 			["DTSTART:20170101\nRRULE:FREQ=DAILY;INTERVAL=2", '2017-01-02', true, 2, [date_create('2017-01-03'),date_create('2017-01-05')]],


### PR DESCRIPTION
I noticed that getOccurrencesAfter is returning an empty array when $inclusive is false and $limit is not set.
This PR fixes it.