### PR TITLE
Added swedish translation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Feel free to contribute! Just create a new issue or a new pull request.
 
 The coding style is (mostly) PSR-2, but with tabs.
 
+
+## Translation
+Use ```php src/reviewTranslations <locale>``` to print a list of examples using the
+locale specified. The list is in no way exclusive, so add more examples to make proofing translations easier.
+
 ## Note
 
 I started this library because I wasn't happy with the existing implementations

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Translation file for English language.
+ * Translation file for Swedish language.
  *
  * Most strings can be an array, with a value as the key. The system will
  * pick the translation corresponding to the key. The key "else" will be picked

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Translation file for English language.
+ *
+ * Most strings can be an array, with a value as the key. The system will
+ * pick the translation corresponding to the key. The key "else" will be picked
+ * if no matching value is found. This is useful for plurals.
+ *
+ * Licensed under the MIT license.
+ *
+ * For the full copyright and license information, please view the LICENSE file.
+ *
+ * @author Rémi Lanvin <remi@cloudconnected.fr>
+ * @link https://github.com/rlanvin/php-rrule
+ */
+return array(
+	'yearly' => array(
+		'1' => 'årligen',
+		'2' => 'vartannat år',
+		'else' => 'var %{interval}:e år'
+	),
+	'monthly' => array(
+		'1' => 'månatligen',
+		'2' => 'varannan månad',
+		'else' => 'var %{interval}:e månad'
+	),
+	'weekly' => array(
+		'1' => 'varje vecka',
+		'2' => 'varannan vecka',
+		'else' => 'var %{interval}:e vecka'
+	),
+	'daily' => array(
+		'1' => 'dagligen',
+		'2' => 'varannnan dag',
+		'else' => 'var %{interval}:e dag'
+	),
+	'hourly' => array(
+		'1' => 'varje timme',
+		'2' => 'varannan timme',
+		'else' => 'var %{interval}:e timme'
+	),
+	'minutely' => array(
+		'1' => 'varje minut',
+		'2' => 'varannan minut',
+		'else' => 'var %{interval}:e minut'
+	),
+	'secondly' => array(
+		'1' => 'varje sekund',
+		'2' => 'varannan sekund',
+		'else' => 'var %{interval}:e sekund'
+	),
+	'dtstart' => ', börjar %{date}',
+	'infinite' => ', tills vidare',
+	'until' => ', t.om %{date}',
+	'count' => array(
+		'1' => ', ett tillfälle',
+		'else' => ', %{count} tillfällen'
+	),
+	'and' => 'och',
+	'x_of_the_y' => array(
+		'yearly' => '%{x} på året', // ex. den första måndagen på året, eller den första dagen på året,  e.g. the first Monday of the year, or the first day of the year
+		'monthly' => '%{x} i månaden',
+	),
+	'bymonth' => ' i %{months}',
+	'months' => array(
+		1 => 'Januari',
+		2 => 'Februari',
+		3 => 'Mars',
+		4 => 'April',
+		5 => 'Maj',
+		6 => 'Juni',
+		7 => 'Juli',
+		8 => 'Augusti',
+		9 => 'September',
+		10 => 'Oktober',
+		11 => 'November',
+		12 => 'December',
+	),
+	'byweekday' => ' på %{weekdays}',
+	'weekdays' => array(
+		1 => 'Månday',
+		2 => 'Tisdag',
+		3 => 'Onsdag',
+		4 => 'Torsdag',
+		5 => 'Fredag',
+		6 => 'Lördag',
+		7 => 'Söndag',
+	),
+	'nth_weekday' => array(
+		'1' => 'den första %{weekday}en', // e.g. the first Monday
+		'2' => 'den andra %{weekday}en',
+		'else' => 'den %{n}:e %{weekday}en'
+	),
+	'-nth_weekday' => array(
+		'-1' => 'den sista %{weekday}en', // e.g. the last Monday
+		'-2' => 'näst sista %{weekday}en',
+		'else' => 'den %{n}:e %{weekday}en från slutet'
+	),
+	'byweekno' => array(
+		'1' => ' i vecka %{weeks}',
+		'else' => ' i vecka %{weeks}'
+	),
+	'nth_weekno' => '%{n}',
+	'bymonthday' => '%{monthdays}',
+	'nth_monthday' => array(
+		'1' => 'den 1:a',
+		'2' => 'den 2:a',
+		'3' => 'den 3:e',
+		'21' => 'den 21:a',
+		'22' => 'den 22:a',
+		'23' => 'den 23:e',
+		'31' => 'den 31:a',
+		'else' => 'den %{n}:e'
+	),
+	'-nth_monthday' => array(
+		'-1' => 'sista dagen',
+		'-2' => 'den näst sista dagen',
+		'else' => '%{n} dagar från sista dagen'
+	),
+	'byyearday' => array(
+		'else' => ' på %{yeardays} dagen'
+	),
+	'nth_yearday' => array(
+		'1' => 'den första',
+		'2' => 'den andra',
+		'3' => 'den tredje',
+		'else' => 'den %{n}:e'
+	),
+	'-nth_yearday' => array(
+		'-1' => 'sista',
+		'-2' => 'den näst sista',
+		'else' => '%{n} från sista'
+	),
+	'byhour' => array(
+		'else' => ' vid %{hours}'
+	),
+	'nth_hour' => '%{n}',
+	'byminute' => array(
+		'else' => '.%{minutes}'
+	),
+	'nth_minute' => '%{n}',
+	'bysecond' => array(
+		'else' => '.%{seconds}'
+	),
+	'nth_second' => '%{n}',
+	'bysetpos' => ', men bara %{setpos} tillfället i serien',
+	'nth_setpos' => array(
+		'1' => 'det första',
+		'2' => 'det andra',
+		'3' => 'det tredje',
+		'else' => 'det %{n}:e'
+	),
+	'-nth_setpos' => array(
+		'-1' => 'det sista',
+		'-2' => 'det näst sista',
+		'else' => 'det %{n}:e sista'
+	)
+);

--- a/src/reviewTranslations.php
+++ b/src/reviewTranslations.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+use RRule\RRule;
+
+require(__DIR__ . '/../vendor/autoload.php');
+
+$locale = isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : 'en';
+
+
+$rruleExamples = array(
+	array(
+		'FREQ' => 'YEARLY',
+		'INTERVAL' => 1,
+		'DTSTART' => '2015-06-01',
+		'COUNT' => 6
+	),
+	array(
+		'FREQ' => 'MONTHLY',
+		'INTERVAL' => 3,
+		'DTSTART' => date_create('1997-01-01')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 2,
+		'BYDAY' => 'TU',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 2,
+		'BYDAY' => 'TU',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 2,
+		'BYDAY' => 'TU,FR',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 1,
+		'BYDAY' => 'TU',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 1,
+		'BYDAY' => 'TU',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'YEARLY',
+		'COUNT' => 1,
+		'BYDAY' => 'TU',
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'HOURLY',
+		'COUNT' => 1,
+		'BYHOUR' => 21,
+		'BYMINUTE' => 10,
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'MINUTELY',
+		'COUNT' => 1,
+		'BYHOUR' => 21,
+		'BYMINUTE' => 10,
+		'DTSTART' => date_create('1997-09-02 09:00')
+	),
+	array(
+		'FREQ' => 'MINUTELY',
+		'BYHOUR' => 21,
+		'BYMINUTE' => 10,
+	),
+	array(
+		'FREQ' => 'SECONDLY',
+		'BYHOUR' => 21,
+		'BYMINUTE' => 10,
+		'BYSECOND' => 10,
+	),
+);
+
+foreach ($rruleExamples as $rruleExampleNr => $rruleDefinition) {
+	$rrule = new RRule($rruleDefinition);
+	echo '$rruleExamples #' . $rruleExampleNr . ': ' . $rrule->humanReadable(['locale' => $locale]) . "\n";
+
+
+}
+
+

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -2017,7 +2017,7 @@ class RRuleTest extends TestCase
 ///////////////////////////////////////////////////////////////////////////////
 // RFC Strings
 
-	public function rfcStrings() 
+	public function rfcStrings()
 	{
 		return array(
 			// full RFC string
@@ -2164,7 +2164,7 @@ class RRuleTest extends TestCase
 	{
 		$rule = new RRule($str);
 
-		// test that parsing the string produces the same result 
+		// test that parsing the string produces the same result
 		// as generating the string from a rule
 		$this->assertEquals($rule, new RRule($rule->rfcString()));
 
@@ -2201,7 +2201,7 @@ class RRuleTest extends TestCase
 	public function quirkyRfcStrings()
 	{
 		return array(
-			array('DTSTART=20160202T000000Z;FREQ=DAILY;UNTIL=20160205T000000Z', 
+			array('DTSTART=20160202T000000Z;FREQ=DAILY;UNTIL=20160205T000000Z',
 				array(
 					date_create('2016-02-02', new DateTimeZone('UTC')),
 					date_create('2016-02-03', new DateTimeZone('UTC')),
@@ -2209,7 +2209,7 @@ class RRuleTest extends TestCase
 					date_create('2016-02-05', new DateTimeZone('UTC'))
 				)
 			),
-			array('RRULE:DTSTART=20160202T000000Z;FREQ=DAILY;UNTIL=20160205T000000Z', 
+			array('RRULE:DTSTART=20160202T000000Z;FREQ=DAILY;UNTIL=20160205T000000Z',
 				array(
 					date_create('2016-02-02', new DateTimeZone('UTC')),
 					date_create('2016-02-03', new DateTimeZone('UTC')),
@@ -2220,7 +2220,7 @@ class RRuleTest extends TestCase
 		);
 	}
 
-	/** 
+	/**
 	 * @dataProvider quirkyRfcStrings
 	 */
 	public function testQuirkyRfcStringsParserNotice($str,$occurrences)
@@ -2733,14 +2733,14 @@ class RRuleTest extends TestCase
 		}
 		$this->assertEquals(date_create('2007-01-01'), $occurrence);
 		$occurrence->modify('+1 day');
-		$this->assertEquals(date_create('2007-01-01'), $rrule[0], 'No modification possible with foreach (uncached)'); 
+		$this->assertEquals(date_create('2007-01-01'), $rrule[0], 'No modification possible with foreach (uncached)');
 
 		foreach ($rrule as $occurrence) {
 			break;
 		}
 		$this->assertEquals(date_create('2007-01-01'), $occurrence);
 		$occurrence->modify('+1 day');
-		$this->assertEquals(date_create('2007-01-01'), $rrule[0], 'No modification possible with foreach (cached)'); 
+		$this->assertEquals(date_create('2007-01-01'), $rrule[0], 'No modification possible with foreach (cached)');
 
 		// getOccurrences
 		$occurrences = $rrule->getOccurrences();
@@ -2943,15 +2943,19 @@ class RRuleTest extends TestCase
 			// 2 characters language code
 			array('en', array('en'), array('en')),
 			array('fr', array('fr'), array('fr')),
+			array('sv', array('sv'), array('sv')),
 			// with region and underscore
 			array('en_US', array('en','en_US'), array('en','en_US')),
 			array('en_US.utf-8', array('en','en_US'), array('en','en_US')),
-			array('en_US_POSIX', array('en','en_US'), array('en','en_US')),
-			// case insentitive
+            array('en_US_POSIX', array('en','en_US'), array('en','en_US')),
+            array('sv_SE', array('sv','sv_SE'), array('sv','sv_SE')),
+            // case insentitive
 			array('en_sg', array('en','en_SG'), array('en','en_SG')),
+			array('sv_se', array('sv','sv_SE'), array('sv','sv_SE')),
 			// with a dash
 			array('en-US', array('en','en_US'), array('en','en_US')),
 			array('zh-Hant-TW', array('zh','zh_TW'), array('zh','zh_TW')), // real locale is zh-Hant-TW, but since we don't have a "zh" file, we just use "en" for the test
+            array('sv-SE', array('sv','sv_SE'), array('sv','sv_SE')),
 
 			// invalid
 			array('eng', array('en'), false),
@@ -3095,7 +3099,7 @@ class RRuleTest extends TestCase
 		)); // the locales are correctly formatted, but not such file exist, so this should throw a RuntimeException
 	}
 
-	/** 
+	/**
 	 * Test that humanReadable works
 	 */
 	public function testHumanReadableWithCLocale()


### PR DESCRIPTION
Added a swedish translation file, could be used for sv_SE and possibly also for sv_FI.

Also added a way to print a list of examples of translations to verify that the translation works well.
Use ```php src/reviewTranslations <locale>``` to print a list of examples using the
locale specified. The list is in no way exclusive, so add more examples to make proofing translations easier.

Feel free to remove/move the reviewTranslations.php if it is not a needed feature.