### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4','8.0']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php }}
     steps:
     - name: Checkout

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -1325,9 +1325,9 @@ class RRule implements RRuleInterface
 	 * (I don't know yet which one first), and then if that results in a change of
 	 * month, attempt to jump to the next BYMONTH, and so on.
 	 *
-	 * @return \iterable
+	 * @return iterable
 	 */
-	public function getIterator(): \iterable
+	public function getIterator(): iterable
 	{
 		$total = 0;
 		$occurrence = null;

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -917,7 +917,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -925,6 +925,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		if (! is_numeric($offset) || $offset < 0 || is_float($offset)) {
@@ -957,7 +958,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new \LogicException('Setting a Date in a RRule is not supported');
 	}
@@ -965,7 +966,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new \LogicException('Unsetting a Date in a RRule is not supported');
 	}
@@ -980,7 +981,7 @@ class RRule implements RRuleInterface
 	 *
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		if ($this->isInfinite()) {
 			throw new \LogicException('Cannot count an infinite recurrence rule.');
@@ -1324,9 +1325,9 @@ class RRule implements RRuleInterface
 	 * (I don't know yet which one first), and then if that results in a change of
 	 * month, attempt to jump to the next BYMONTH, and so on.
 	 *
-	 * @return \DateTime|null
+	 * @return \iterable
 	 */
-	public function getIterator()
+	public function getIterator(): \iterable
 	{
 		$total = 0;
 		$occurrence = null;
@@ -1725,7 +1726,6 @@ class RRule implements RRuleInterface
 		}
 
 		$this->total = $total; // save total for count cache
-		return; // stop the iterator
 	}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -917,7 +917,8 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset): bool
+	#[\ReturnTypeWillChange]
+	public function offsetExists($offset)
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -958,7 +959,8 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value): void
+	#[\ReturnTypeWillChange]
+	public function offsetSet($offset, $value)
 	{
 		throw new \LogicException('Setting a Date in a RRule is not supported');
 	}
@@ -966,7 +968,8 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset): void
+	#[\ReturnTypeWillChange]
+	public function offsetUnset($offset)
 	{
 		throw new \LogicException('Unsetting a Date in a RRule is not supported');
 	}
@@ -981,7 +984,8 @@ class RRule implements RRuleInterface
 	 *
 	 * @return int
 	 */
-	public function count(): int
+	#[\ReturnTypeWillChange]
+	public function count()
 	{
 		if ($this->isInfinite()) {
 			throw new \LogicException('Cannot count an infinite recurrence rule.');
@@ -1325,9 +1329,10 @@ class RRule implements RRuleInterface
 	 * (I don't know yet which one first), and then if that results in a change of
 	 * month, attempt to jump to the next BYMONTH, and so on.
 	 *
-	 * @return iterable
+	 * @return \DateTime|null
 	 */
-	public function getIterator(): iterable
+	#[\ReturnTypeWillChange]
+	public function getIterator()
 	{
 		$total = 0;
 		$occurrence = null;
@@ -1726,6 +1731,7 @@ class RRule implements RRuleInterface
 		}
 
 		$this->total = $total; // save total for count cache
+		return; // stop the iterator
 	}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/RSet.php
+++ b/src/RSet.php
@@ -489,7 +489,8 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset): bool
+	#[\ReturnTypeWillChange]
+	public function offsetExists($offset)
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -530,7 +531,8 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value): void
+	#[\ReturnTypeWillChange]
+	public function offsetSet($offset, $value)
 	{
 		throw new \LogicException('Setting a Date in a RSet is not supported (use addDate)');
 	}
@@ -538,7 +540,8 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset): void
+	#[\ReturnTypeWillChange]
+	public function offsetUnset($offset)
 	{
 		throw new \LogicException('Unsetting a Date in a RSet is not supported (use addDate)');
 	}
@@ -552,7 +555,8 @@ class RSet implements RRuleInterface
 	 * introduces a performance penality.
 	 * @return int
 	 */
-	public function count(): int
+	#[\ReturnTypeWillChange]
+	public function count()
 	{
 		if ($this->isInfinite()) {
 			throw new \LogicException('Cannot count an infinite recurrence set.');
@@ -587,9 +591,10 @@ class RSet implements RRuleInterface
 	 * This is made slightly more complicated because this method is a generator.
 	 *
 	 * @param $reset (bool) Whether to restart the iteration, or keep going
-	 * @return iterable
+	 * @return \DateTime|null
 	 */
-	public function getIterator(): iterable
+	#[\ReturnTypeWillChange]
+	public function getIterator()
 	{
 		$previous_occurrence = null;
 		$total = 0;
@@ -683,5 +688,6 @@ class RSet implements RRuleInterface
 		}
 
 		$this->total = $total; // save total for count cache
+		return; // stop the iterator
 	}
 }

--- a/src/RSet.php
+++ b/src/RSet.php
@@ -489,7 +489,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -497,6 +497,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		if (! is_numeric($offset) || $offset < 0 || is_float($offset)) {
@@ -529,7 +530,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new \LogicException('Setting a Date in a RSet is not supported (use addDate)');
 	}
@@ -537,7 +538,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new \LogicException('Unsetting a Date in a RSet is not supported (use addDate)');
 	}
@@ -551,7 +552,7 @@ class RSet implements RRuleInterface
 	 * introduces a performance penality.
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		if ($this->isInfinite()) {
 			throw new \LogicException('Cannot count an infinite recurrence set.');
@@ -586,9 +587,9 @@ class RSet implements RRuleInterface
 	 * This is made slightly more complicated because this method is a generator.
 	 *
 	 * @param $reset (bool) Whether to restart the iteration, or keep going
-	 * @return \DateTime|null
+	 * @return \iterable
 	 */
-	public function getIterator()
+	public function getIterator(): \iterable
 	{
 		$previous_occurrence = null;
 		$total = 0;
@@ -682,6 +683,5 @@ class RSet implements RRuleInterface
 		}
 
 		$this->total = $total; // save total for count cache
-		return; // stop the iterator
 	}
 }

--- a/src/RSet.php
+++ b/src/RSet.php
@@ -587,9 +587,9 @@ class RSet implements RRuleInterface
 	 * This is made slightly more complicated because this method is a generator.
 	 *
 	 * @param $reset (bool) Whether to restart the iteration, or keep going
-	 * @return \iterable
+	 * @return iterable
 	 */
-	public function getIterator(): \iterable
+	public function getIterator(): iterable
 	{
 		$previous_occurrence = null;
 		$total = 0;


### PR DESCRIPTION
Fixes following deprecation notices on PHP 8.1.

```
Return type of RRule\RSet::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of RRule\RSet::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of RRule\RSet::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of RRule\RSet::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of RRule\RSet::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```