### PR TITLE
Human readable time of day option

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -115,7 +115,7 @@ class RRule implements RRuleInterface
 		'YEARLY' => self::YEARLY
 	);
 
-	/**
+	/** 
 	 * Weekdays numbered from 1 (ISO-8601 or `date('N')`).
 	 * Used internally but public if a reference list is needed.
 	 */
@@ -266,7 +266,7 @@ class RRule implements RRuleInterface
 					'Failed to parse DTSTART ; it must be a valid date, timestamp or \DateTime object'
 				);
 			}
-		}
+		} 
 		else {
 			$this->dtstart = new \DateTime(); // for PHP 7.1+ this contains microseconds which causes many problems
 			if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
@@ -908,7 +908,7 @@ class RRule implements RRuleInterface
 		}
 
 		// we ended the loop without finding
-		return false;
+		return false; 
 	}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1252,7 +1252,7 @@ class RRule implements RRuleInterface
 	 * - for HOURLY frequencies it builds the minutes and second of the given hour
 	 * - for MINUTELY frequencies it builds the seconds of the given minute
 	 * - for SECONDLY frequencies, it returns an array with one element
-	 *
+	 * 
 	 * This method is called everytime an increment of at least one hour is made.
 	 *
 	 * @param int $hour
@@ -1294,7 +1294,7 @@ class RRule implements RRuleInterface
 	 *
 	 * The main idea is: a brute force loop testing all the dates, made fast by
 	 * not relying on date() functions
-	 *
+	 * 
 	 * There is one big loop that examines every interval of the given frequency
 	 * (so every day, every week, every month or every year), constructs an
 	 * array of all the yeardays of the interval (for daily frequencies, the array
@@ -1318,7 +1318,7 @@ class RRule implements RRuleInterface
 	 * convoluted.
 	 * Moreover, at such frequencies, the brute-force approach starts to really
 	 * suck. For example, a rule like
-	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years"
+	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years" 
 	 * requires a tremendous amount of useless iterations to jump from Jan 1st 10:59
 	 * at year 1 to Jan 1st 10.00 at year 2.
 	 *
@@ -1711,7 +1711,7 @@ class RRule implements RRuleInterface
 							}
 						}
 						if ((! $this->byhour || in_array($hour, $this->byhour))
-							&& (! $this->byminute || in_array($minute, $this->byminute))
+							&& (! $this->byminute || in_array($minute, $this->byminute)) 
 							&& (! $this->bysecond || in_array($second, $this->bysecond))) {
 							$found = true;
 							break;
@@ -1862,7 +1862,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @var array
 	 * Maximum number of cycles after which a calendar repeats itself. This
-	 * is used to detect infinite loop: if no occurrence has been found
+	 * is used to detect infinite loop: if no occurrence has been found 
 	 * after this numbers of cycles, we can abort.
 	 *
 	 * The Gregorian calendar cycle repeat completely every 400 years
@@ -1902,7 +1902,7 @@ class RRule implements RRuleInterface
 	 */
 	static protected $intl_loaded = null;
 
-	/**
+	/** 
 	 * Select a translation in $array based on the value of $n
 	 *
 	 * Used for selecting plural forms.
@@ -1954,7 +1954,7 @@ class RRule implements RRuleInterface
 		}
 	}
 
-	/**
+	/** 
 	 * Test if intl extension is loaded
 	 * @return bool
 	 */
@@ -1981,7 +1981,7 @@ class RRule implements RRuleInterface
 			$use_intl = self::intlLoaded();
 		}
 		$files = array();
-
+		
 		if ($use_intl) {
 			$parsed = \Locale::parseLocale($locale);
 			$files[] = $parsed['language'];

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2405,9 +2405,10 @@ class RRule implements RRuleInterface
 		}
 
         if ($opt['include_timeofday']) {
-            // from X
-            $parts['timeofday'] = strtr($i18n['timeofday'], array(
-                '%{timeofday}' => $opt['timeofday_formatter']($this->dtstart)
+            // at X
+            $value = ($this->freq >= self::HOURLY ? 'startingtimeofday' : 'timeofday');
+            $parts['timeofday'] = strtr($i18n[$value], array(
+                '%{timeofday}' => $opt['timeofday_formatter']($this->dtstart),
             ));
         }
 

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2068,11 +2068,11 @@ class RRule implements RRuleInterface
 	 * | `locale`              | string  | The locale to use (autodetect)
 	 * | `fallback`            | string  | Fallback locale if main locale is not found (default en)
 	 * | `date_formatter`      | callable| Function used to format the date (takes date, returns formatted)
-     * | `timeofday_formatter` | callable| Function used to format the timeofday (takes date, returns formatted)
+	 * | `timeofday_formatter` | callable| Function used to format the timeofday (takes date, returns formatted)
 	 * | `explicit_inifite`    | bool    | Mention "forever" if the rule is infinite (true)
 	 * | `dtstart`             | bool    | Mention the start date (true)
 	 * | `include_start`       | bool    |
-       | `include_timeofday`   | bool    |
+	 * | `include_timeofday`   | bool    |
 	 * | `include_until`       | bool    |
 	 * | `custom_path`         | string  |
 	 *
@@ -2090,11 +2090,11 @@ class RRule implements RRuleInterface
 			'use_intl' => self::intlLoaded(),
 			'locale' => null,
 			'date_formatter' => null,
-            'timeofday_formatter' => null,
+			'timeofday_formatter' => null,
 			'fallback' => 'en',
 			'explicit_infinite' => true,
 			'include_start' => true,
-            'include_timeofday' => false,
+			'include_timeofday' => false,
 			'include_until' => true,
 			'custom_path' => null
 		);
@@ -2125,11 +2125,11 @@ class RRule implements RRuleInterface
 			}
 		}
 
-        $opt = array_merge($default_opt, $opt);
-        if ($opt['include_timeofday']) {
-            // timeofday does not mix well with start date, so it should be turned off
-            $opt['include_start'] = false;
-        }
+		$opt = array_merge($default_opt, $opt);
+		if ($opt['include_timeofday']) {
+        	// timeofday does not mix well with start date, so it should be turned off
+			$opt['include_start'] = false;
+		}
 
 		$i18n = self::i18nLoad($opt['locale'], $opt['fallback'], $opt['use_intl'], $opt['custom_path']);
 
@@ -2165,37 +2165,37 @@ class RRule implements RRuleInterface
 			}
 		}
 
-        if ($opt['timeofday_formatter'] && ! is_callable($opt['timeofday_formatter'])) {
-            throw new \InvalidArgumentException('The option timeofday_formatter must callable');
-        }
+		if ($opt['timeofday_formatter'] && ! is_callable($opt['timeofday_formatter'])) {
+			throw new \InvalidArgumentException('The option timeofday_formatter must callable');
+		}
 
-        if (! $opt['timeofday_formatter']) {
-            if ($opt['use_intl']) {
-                $timezone = $this->dtstart->getTimezone()->getName();
-                if ($timezone === 'Z') {
-                    $timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
-                } elseif (preg_match('/[-+]\d{2}/',$timezone)) {
-                    $timezone = 'GMT'.$timezone; // otherwise IntlDateFormatter::create fails because... other reasons.
-                }
-                $formatter = \IntlDateFormatter::create(
-                    $opt['locale'],
-                    \IntlDateFormatter::NONE,
-                    $opt['timeofday_format'],
-                    $timezone
-                );
-                if (! $formatter) {
-                    throw new \RuntimeException('IntlDateFormatter::create() failed. Error Code: '.intl_get_error_code().' "'. intl_get_error_message().'" (this should not happen, please open a bug report!)');
-                }
-                $opt['timeofday_formatter'] = function($date) use ($formatter) {
-                    return $formatter->format($date);
-                };
-            }
-            else {
-                $opt['timeofday_formatter'] = function($date) {
-                    return $date->format('H:i:s');
-                };
-            }
-        }
+		if (! $opt['timeofday_formatter']) {
+			if ($opt['use_intl']) {
+				$timezone = $this->dtstart->getTimezone()->getName();
+				if ($timezone === 'Z') {
+					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
+				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {
+					$timezone = 'GMT'.$timezone; // otherwise IntlDateFormatter::create fails because... other reasons.
+				}
+				$formatter = \IntlDateFormatter::create(
+					$opt['locale'],
+					\IntlDateFormatter::NONE,
+					$opt['timeofday_format'],
+					$timezone
+				);
+				if (! $formatter) {
+					throw new \RuntimeException('IntlDateFormatter::create() failed. Error Code: '.intl_get_error_code().' "'. intl_get_error_message().'" (this should not happen, please open a bug report!)');
+				}
+				$opt['timeofday_formatter'] = function($date) use ($formatter) {
+					return $formatter->format($date);
+				};
+			}
+			else {
+				$opt['timeofday_formatter'] = function($date) {
+					return $date->format('H:i:s');
+				};
+			}
+		}
 
         $parts = array(
 			'freq' => '',
@@ -2404,13 +2404,13 @@ class RRule implements RRuleInterface
 			));
 		}
 
-        if ($opt['include_timeofday']) {
-            // at X
-            $value = ($this->freq >= self::HOURLY ? 'startingtimeofday' : 'timeofday');
-            $parts['timeofday'] = strtr($i18n[$value], array(
-                '%{timeofday}' => $opt['timeofday_formatter']($this->dtstart),
-            ));
-        }
+		if ($opt['include_timeofday']) {
+			// at X
+			$value = ($this->freq >= self::HOURLY ? 'startingtimeofday' : 'timeofday');
+			$parts['timeofday'] = strtr($i18n[$value], array(
+				'%{timeofday}' => $opt['timeofday_formatter']($this->dtstart),
+			));
+		}
 
 		// to X, or N times, or indefinitely
 		if ($opt['include_until']) {

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2108,7 +2108,7 @@ class RRule implements RRuleInterface
 		}
 
 		if ($opt['use_intl']) {
-			$default_opt['date_format'] = \IntlDateFormatter::SHORT;
+			$default_opt['date_format'] = isset($opt['start_time_only']) && $opt['start_time_only'] ? \IntlDateFormatter::NONE : \IntlDateFormatter::SHORT;
 			if ($this->freq >= self::SECONDLY || not_empty($this->rule['BYSECOND'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::LONG;
 			}
@@ -2132,9 +2132,6 @@ class RRule implements RRuleInterface
 			if ($opt['use_intl']) {
 				$timezone = $this->dtstart->getTimezone()->getName();
 
-				if ($opt['start_time_only']) {
-					$opt['date_format'] = \IntlDateFormatter::NONE;
-				}
 				if ($timezone === 'Z') {
 					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
 				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -115,7 +115,7 @@ class RRule implements RRuleInterface
 		'YEARLY' => self::YEARLY
 	);
 
-	/**
+	/** 
 	 * Weekdays numbered from 1 (ISO-8601 or `date('N')`).
 	 * Used internally but public if a reference list is needed.
 	 */
@@ -266,7 +266,7 @@ class RRule implements RRuleInterface
 					'Failed to parse DTSTART ; it must be a valid date, timestamp or \DateTime object'
 				);
 			}
-		}
+		} 
 		else {
 			$this->dtstart = new \DateTime(); // for PHP 7.1+ this contains microseconds which causes many problems
 			if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
@@ -908,7 +908,7 @@ class RRule implements RRuleInterface
 		}
 
 		// we ended the loop without finding
-		return false;
+		return false; 
 	}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1252,7 +1252,7 @@ class RRule implements RRuleInterface
 	 * - for HOURLY frequencies it builds the minutes and second of the given hour
 	 * - for MINUTELY frequencies it builds the seconds of the given minute
 	 * - for SECONDLY frequencies, it returns an array with one element
-	 *
+	 * 
 	 * This method is called everytime an increment of at least one hour is made.
 	 *
 	 * @param int $hour
@@ -1294,7 +1294,7 @@ class RRule implements RRuleInterface
 	 *
 	 * The main idea is: a brute force loop testing all the dates, made fast by
 	 * not relying on date() functions
-	 *
+	 * 
 	 * There is one big loop that examines every interval of the given frequency
 	 * (so every day, every week, every month or every year), constructs an
 	 * array of all the yeardays of the interval (for daily frequencies, the array
@@ -1318,7 +1318,7 @@ class RRule implements RRuleInterface
 	 * convoluted.
 	 * Moreover, at such frequencies, the brute-force approach starts to really
 	 * suck. For example, a rule like
-	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years"
+	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years" 
 	 * requires a tremendous amount of useless iterations to jump from Jan 1st 10:59
 	 * at year 1 to Jan 1st 10.00 at year 2.
 	 *
@@ -1711,7 +1711,7 @@ class RRule implements RRuleInterface
 							}
 						}
 						if ((! $this->byhour || in_array($hour, $this->byhour))
-							&& (! $this->byminute || in_array($minute, $this->byminute))
+							&& (! $this->byminute || in_array($minute, $this->byminute)) 
 							&& (! $this->bysecond || in_array($second, $this->bysecond))) {
 							$found = true;
 							break;
@@ -1862,7 +1862,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @var array
 	 * Maximum number of cycles after which a calendar repeats itself. This
-	 * is used to detect infinite loop: if no occurrence has been found
+	 * is used to detect infinite loop: if no occurrence has been found 
 	 * after this numbers of cycles, we can abort.
 	 *
 	 * The Gregorian calendar cycle repeat completely every 400 years
@@ -1902,7 +1902,7 @@ class RRule implements RRuleInterface
 	 */
 	static protected $intl_loaded = null;
 
-	/**
+	/** 
 	 * Select a translation in $array based on the value of $n
 	 *
 	 * Used for selecting plural forms.
@@ -1954,7 +1954,7 @@ class RRule implements RRuleInterface
 		}
 	}
 
-	/**
+	/** 
 	 * Test if intl extension is loaded
 	 * @return bool
 	 */
@@ -1981,7 +1981,7 @@ class RRule implements RRuleInterface
 			$use_intl = self::intlLoaded();
 		}
 		$files = array();
-
+		
 		if ($use_intl) {
 			$parsed = \Locale::parseLocale($locale);
 			$files[] = $parsed['language'];
@@ -2140,6 +2140,7 @@ class RRule implements RRuleInterface
 		if (! $opt['date_formatter']) {
 			if ($opt['use_intl']) {
 				$timezone = $this->dtstart->getTimezone()->getName();
+
 				if ($timezone === 'Z') {
 					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
 				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {
@@ -2197,7 +2198,7 @@ class RRule implements RRuleInterface
 			}
 		}
 
-        $parts = array(
+		$parts = array(
 			'freq' => '',
 			'byweekday' => '',
 			'bymonth' => '',

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2113,21 +2113,21 @@ class RRule implements RRuleInterface
 			$default_opt['date_format'] = \IntlDateFormatter::SHORT;
 			if ($this->freq >= self::SECONDLY || not_empty($this->rule['BYSECOND'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::LONG;
-                $default_opt['timeofday_format'] = \IntlDateFormatter::LONG;
+				$default_opt['timeofday_format'] = \IntlDateFormatter::LONG;
 			}
 			elseif ($this->freq >= self::HOURLY || not_empty($this->rule['BYHOUR']) || not_empty($this->rule['BYMINUTE'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::SHORT;
-                $default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
+				$default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
 			}
 			else {
 				$default_opt['time_format'] = \IntlDateFormatter::NONE;
-                $default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
+				$default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
 			}
 		}
 
 		$opt = array_merge($default_opt, $opt);
 		if ($opt['include_timeofday']) {
-        	// timeofday does not mix well with start date, so it should be turned off
+			// timeofday does not mix well with start date, so it should be turned off
 			$opt['include_start'] = false;
 		}
 

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -115,7 +115,7 @@ class RRule implements RRuleInterface
 		'YEARLY' => self::YEARLY
 	);
 
-	/** 
+	/**
 	 * Weekdays numbered from 1 (ISO-8601 or `date('N')`).
 	 * Used internally but public if a reference list is needed.
 	 */
@@ -266,7 +266,7 @@ class RRule implements RRuleInterface
 					'Failed to parse DTSTART ; it must be a valid date, timestamp or \DateTime object'
 				);
 			}
-		} 
+		}
 		else {
 			$this->dtstart = new \DateTime(); // for PHP 7.1+ this contains microseconds which causes many problems
 			if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
@@ -908,7 +908,7 @@ class RRule implements RRuleInterface
 		}
 
 		// we ended the loop without finding
-		return false; 
+		return false;
 	}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1252,7 +1252,7 @@ class RRule implements RRuleInterface
 	 * - for HOURLY frequencies it builds the minutes and second of the given hour
 	 * - for MINUTELY frequencies it builds the seconds of the given minute
 	 * - for SECONDLY frequencies, it returns an array with one element
-	 * 
+	 *
 	 * This method is called everytime an increment of at least one hour is made.
 	 *
 	 * @param int $hour
@@ -1294,7 +1294,7 @@ class RRule implements RRuleInterface
 	 *
 	 * The main idea is: a brute force loop testing all the dates, made fast by
 	 * not relying on date() functions
-	 * 
+	 *
 	 * There is one big loop that examines every interval of the given frequency
 	 * (so every day, every week, every month or every year), constructs an
 	 * array of all the yeardays of the interval (for daily frequencies, the array
@@ -1318,7 +1318,7 @@ class RRule implements RRuleInterface
 	 * convoluted.
 	 * Moreover, at such frequencies, the brute-force approach starts to really
 	 * suck. For example, a rule like
-	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years" 
+	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years"
 	 * requires a tremendous amount of useless iterations to jump from Jan 1st 10:59
 	 * at year 1 to Jan 1st 10.00 at year 2.
 	 *
@@ -1711,7 +1711,7 @@ class RRule implements RRuleInterface
 							}
 						}
 						if ((! $this->byhour || in_array($hour, $this->byhour))
-							&& (! $this->byminute || in_array($minute, $this->byminute)) 
+							&& (! $this->byminute || in_array($minute, $this->byminute))
 							&& (! $this->bysecond || in_array($second, $this->bysecond))) {
 							$found = true;
 							break;
@@ -1862,7 +1862,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @var array
 	 * Maximum number of cycles after which a calendar repeats itself. This
-	 * is used to detect infinite loop: if no occurrence has been found 
+	 * is used to detect infinite loop: if no occurrence has been found
 	 * after this numbers of cycles, we can abort.
 	 *
 	 * The Gregorian calendar cycle repeat completely every 400 years
@@ -1902,7 +1902,7 @@ class RRule implements RRuleInterface
 	 */
 	static protected $intl_loaded = null;
 
-	/** 
+	/**
 	 * Select a translation in $array based on the value of $n
 	 *
 	 * Used for selecting plural forms.
@@ -1954,7 +1954,7 @@ class RRule implements RRuleInterface
 		}
 	}
 
-	/** 
+	/**
 	 * Test if intl extension is loaded
 	 * @return bool
 	 */
@@ -1981,7 +1981,7 @@ class RRule implements RRuleInterface
 			$use_intl = self::intlLoaded();
 		}
 		$files = array();
-		
+
 		if ($use_intl) {
 			$parsed = \Locale::parseLocale($locale);
 			$files[] = $parsed['language'];
@@ -2062,19 +2062,18 @@ class RRule implements RRuleInterface
 	 *
 	 * Available options
 	 *
-	 * | Name                  | Type    | Description
-	 * |-----------------------|---------|------------
-	 * | `use_intl`            | bool    | Use the intl extension or not (autodetect)
-	 * | `locale`              | string  | The locale to use (autodetect)
-	 * | `fallback`            | string  | Fallback locale if main locale is not found (default en)
-	 * | `date_formatter`      | callable| Function used to format the date (takes date, returns formatted)
-	 * | `timeofday_formatter` | callable| Function used to format the timeofday (takes date, returns formatted)
-	 * | `explicit_inifite`    | bool    | Mention "forever" if the rule is infinite (true)
-	 * | `dtstart`             | bool    | Mention the start date (true)
-	 * | `include_start`       | bool    |
-	 * | `include_timeofday`   | bool    |
-	 * | `include_until`       | bool    |
-	 * | `custom_path`         | string  |
+	 * | Name              | Type    | Description
+	 * |-------------------|---------|------------
+	 * | `use_intl`        | bool    | Use the intl extension or not (autodetect)
+	 * | `locale`          | string  | The locale to use (autodetect)
+	 * | `fallback`        | string  | Fallback locale if main locale is not found (default en)
+	 * | `date_formatter`  | callable| Function used to format the date (takes date, returns formatted)
+	 * | `explicit_inifite`| bool    | Mention "forever" if the rule is infinite (true)
+	 * | `dtstart`         | bool    | Mention the start date (true)
+	 * | `include_start`   | bool    |
+	 * | `start_time_only` | bool    | Mention the time of day only, without the date
+	 * | `include_until`   | bool    |
+	 * | `custom_path`     | string  |
 	 *
 	 * @param array  $opt
 	 *
@@ -2090,11 +2089,10 @@ class RRule implements RRuleInterface
 			'use_intl' => self::intlLoaded(),
 			'locale' => null,
 			'date_formatter' => null,
-			'timeofday_formatter' => null,
 			'fallback' => 'en',
 			'explicit_infinite' => true,
 			'include_start' => true,
-			'include_timeofday' => false,
+			'start_time_only' => false,
 			'include_until' => true,
 			'custom_path' => null
 		);
@@ -2113,23 +2111,16 @@ class RRule implements RRuleInterface
 			$default_opt['date_format'] = \IntlDateFormatter::SHORT;
 			if ($this->freq >= self::SECONDLY || not_empty($this->rule['BYSECOND'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::LONG;
-				$default_opt['timeofday_format'] = \IntlDateFormatter::LONG;
 			}
 			elseif ($this->freq >= self::HOURLY || not_empty($this->rule['BYHOUR']) || not_empty($this->rule['BYMINUTE'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::SHORT;
-				$default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
 			}
 			else {
-				$default_opt['time_format'] = \IntlDateFormatter::NONE;
-				$default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
+				$default_opt['time_format'] = isset($opt['start_time_only']) && $opt['start_time_only'] ? \IntlDateFormatter::SHORT : \IntlDateFormatter::NONE;
 			}
 		}
 
 		$opt = array_merge($default_opt, $opt);
-		if ($opt['include_timeofday']) {
-			// timeofday does not mix well with start date, so it should be turned off
-			$opt['include_start'] = false;
-		}
 
 		$i18n = self::i18nLoad($opt['locale'], $opt['fallback'], $opt['use_intl'], $opt['custom_path']);
 
@@ -2141,6 +2132,9 @@ class RRule implements RRuleInterface
 			if ($opt['use_intl']) {
 				$timezone = $this->dtstart->getTimezone()->getName();
 
+				if ($opt['start_time_only']) {
+					$opt['date_format'] = \IntlDateFormatter::NONE;
+				}
 				if ($timezone === 'Z') {
 					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
 				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {
@@ -2160,40 +2154,9 @@ class RRule implements RRuleInterface
 				};
 			}
 			else {
-				$opt['date_formatter'] = function($date) {
-					return $date->format('Y-m-d H:i:s');
-				};
-			}
-		}
-
-		if ($opt['timeofday_formatter'] && ! is_callable($opt['timeofday_formatter'])) {
-			throw new \InvalidArgumentException('The option timeofday_formatter must callable');
-		}
-
-		if (! $opt['timeofday_formatter']) {
-			if ($opt['use_intl']) {
-				$timezone = $this->dtstart->getTimezone()->getName();
-				if ($timezone === 'Z') {
-					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
-				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {
-					$timezone = 'GMT'.$timezone; // otherwise IntlDateFormatter::create fails because... other reasons.
-				}
-				$formatter = \IntlDateFormatter::create(
-					$opt['locale'],
-					\IntlDateFormatter::NONE,
-					$opt['timeofday_format'],
-					$timezone
-				);
-				if (! $formatter) {
-					throw new \RuntimeException('IntlDateFormatter::create() failed. Error Code: '.intl_get_error_code().' "'. intl_get_error_message().'" (this should not happen, please open a bug report!)');
-				}
-				$opt['timeofday_formatter'] = function($date) use ($formatter) {
-					return $formatter->format($date);
-				};
-			}
-			else {
-				$opt['timeofday_formatter'] = function($date) {
-					return $date->format('H:i:s');
+				$opt['date_formatter'] = function ($date) use ($opt) {
+					$format = $opt['start_time_only'] ? 'H:i:s' : 'Y-m-d H:i:s';
+					return $date->format($format);
 				};
 			}
 		}
@@ -2400,16 +2363,13 @@ class RRule implements RRuleInterface
 
 		if ($opt['include_start']) {
 			// from X
-			$parts['start'] = strtr($i18n['dtstart'], array(
+			if ($opt['start_time_only']) {
+				$value = $this->freq >= self::HOURLY ? 'startingtimeofday' : 'timeofday';
+			} else {
+				$value = 'dtstart';
+			}
+			$parts['start'] = strtr($i18n[$value], array(
 				'%{date}' => $opt['date_formatter']($this->dtstart)
-			));
-		}
-
-		if ($opt['include_timeofday']) {
-			// at X
-			$value = ($this->freq >= self::HOURLY ? 'startingtimeofday' : 'timeofday');
-			$parts['timeofday'] = strtr($i18n[$value], array(
-				'%{timeofday}' => $opt['timeofday_formatter']($this->dtstart),
 			));
 		}
 

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -115,7 +115,7 @@ class RRule implements RRuleInterface
 		'YEARLY' => self::YEARLY
 	);
 
-	/** 
+	/**
 	 * Weekdays numbered from 1 (ISO-8601 or `date('N')`).
 	 * Used internally but public if a reference list is needed.
 	 */
@@ -266,7 +266,7 @@ class RRule implements RRuleInterface
 					'Failed to parse DTSTART ; it must be a valid date, timestamp or \DateTime object'
 				);
 			}
-		} 
+		}
 		else {
 			$this->dtstart = new \DateTime(); // for PHP 7.1+ this contains microseconds which causes many problems
 			if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
@@ -908,7 +908,7 @@ class RRule implements RRuleInterface
 		}
 
 		// we ended the loop without finding
-		return false; 
+		return false;
 	}
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1252,7 +1252,7 @@ class RRule implements RRuleInterface
 	 * - for HOURLY frequencies it builds the minutes and second of the given hour
 	 * - for MINUTELY frequencies it builds the seconds of the given minute
 	 * - for SECONDLY frequencies, it returns an array with one element
-	 * 
+	 *
 	 * This method is called everytime an increment of at least one hour is made.
 	 *
 	 * @param int $hour
@@ -1294,7 +1294,7 @@ class RRule implements RRuleInterface
 	 *
 	 * The main idea is: a brute force loop testing all the dates, made fast by
 	 * not relying on date() functions
-	 * 
+	 *
 	 * There is one big loop that examines every interval of the given frequency
 	 * (so every day, every week, every month or every year), constructs an
 	 * array of all the yeardays of the interval (for daily frequencies, the array
@@ -1318,7 +1318,7 @@ class RRule implements RRuleInterface
 	 * convoluted.
 	 * Moreover, at such frequencies, the brute-force approach starts to really
 	 * suck. For example, a rule like
-	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years" 
+	 * "Every minute, every Jan 1st between 10:00 and 10:59, for 10 years"
 	 * requires a tremendous amount of useless iterations to jump from Jan 1st 10:59
 	 * at year 1 to Jan 1st 10.00 at year 2.
 	 *
@@ -1711,7 +1711,7 @@ class RRule implements RRuleInterface
 							}
 						}
 						if ((! $this->byhour || in_array($hour, $this->byhour))
-							&& (! $this->byminute || in_array($minute, $this->byminute)) 
+							&& (! $this->byminute || in_array($minute, $this->byminute))
 							&& (! $this->bysecond || in_array($second, $this->bysecond))) {
 							$found = true;
 							break;
@@ -1862,7 +1862,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @var array
 	 * Maximum number of cycles after which a calendar repeats itself. This
-	 * is used to detect infinite loop: if no occurrence has been found 
+	 * is used to detect infinite loop: if no occurrence has been found
 	 * after this numbers of cycles, we can abort.
 	 *
 	 * The Gregorian calendar cycle repeat completely every 400 years
@@ -1902,7 +1902,7 @@ class RRule implements RRuleInterface
 	 */
 	static protected $intl_loaded = null;
 
-	/** 
+	/**
 	 * Select a translation in $array based on the value of $n
 	 *
 	 * Used for selecting plural forms.
@@ -1954,7 +1954,7 @@ class RRule implements RRuleInterface
 		}
 	}
 
-	/** 
+	/**
 	 * Test if intl extension is loaded
 	 * @return bool
 	 */
@@ -1981,7 +1981,7 @@ class RRule implements RRuleInterface
 			$use_intl = self::intlLoaded();
 		}
 		$files = array();
-		
+
 		if ($use_intl) {
 			$parsed = \Locale::parseLocale($locale);
 			$files[] = $parsed['language'];
@@ -2062,17 +2062,19 @@ class RRule implements RRuleInterface
 	 *
 	 * Available options
 	 *
-	 * | Name              | Type    | Description
-	 * |-------------------|---------|------------
-	 * | `use_intl`        | bool    | Use the intl extension or not (autodetect)
-	 * | `locale`          | string  | The locale to use (autodetect)
-	 * | `fallback`        | string  | Fallback locale if main locale is not found (default en)
-	 * | `date_formatter`  | callable| Function used to format the date (takes date, returns formatted)
-	 * | `explicit_inifite`| bool    | Mention "forever" if the rule is infinite (true)
-	 * | `dtstart`         | bool    | Mention the start date (true)
-	 * | `include_start`   | bool    |
-	 * | `include_until`   | bool    |
-	 * | `custom_path`     | string  |
+	 * | Name                  | Type    | Description
+	 * |-----------------------|---------|------------
+	 * | `use_intl`            | bool    | Use the intl extension or not (autodetect)
+	 * | `locale`              | string  | The locale to use (autodetect)
+	 * | `fallback`            | string  | Fallback locale if main locale is not found (default en)
+	 * | `date_formatter`      | callable| Function used to format the date (takes date, returns formatted)
+     * | `timeofday_formatter` | callable| Function used to format the timeofday (takes date, returns formatted)
+	 * | `explicit_inifite`    | bool    | Mention "forever" if the rule is infinite (true)
+	 * | `dtstart`             | bool    | Mention the start date (true)
+	 * | `include_start`       | bool    |
+       | `include_timeofday`   | bool    |
+	 * | `include_until`       | bool    |
+	 * | `custom_path`         | string  |
 	 *
 	 * @param array  $opt
 	 *
@@ -2088,9 +2090,11 @@ class RRule implements RRuleInterface
 			'use_intl' => self::intlLoaded(),
 			'locale' => null,
 			'date_formatter' => null,
+            'timeofday_formatter' => null,
 			'fallback' => 'en',
 			'explicit_infinite' => true,
 			'include_start' => true,
+            'include_timeofday' => false,
 			'include_until' => true,
 			'custom_path' => null
 		);
@@ -2109,16 +2113,23 @@ class RRule implements RRuleInterface
 			$default_opt['date_format'] = \IntlDateFormatter::SHORT;
 			if ($this->freq >= self::SECONDLY || not_empty($this->rule['BYSECOND'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::LONG;
+                $default_opt['timeofday_format'] = \IntlDateFormatter::LONG;
 			}
 			elseif ($this->freq >= self::HOURLY || not_empty($this->rule['BYHOUR']) || not_empty($this->rule['BYMINUTE'])) {
 				$default_opt['time_format'] = \IntlDateFormatter::SHORT;
+                $default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
 			}
 			else {
 				$default_opt['time_format'] = \IntlDateFormatter::NONE;
+                $default_opt['timeofday_format'] = \IntlDateFormatter::SHORT;
 			}
 		}
 
-		$opt = array_merge($default_opt, $opt);
+        $opt = array_merge($default_opt, $opt);
+        if ($opt['include_timeofday']) {
+            // timeofday does not mix well with start date, so it should be turned off
+            $opt['include_start'] = false;
+        }
 
 		$i18n = self::i18nLoad($opt['locale'], $opt['fallback'], $opt['use_intl'], $opt['custom_path']);
 
@@ -2129,7 +2140,6 @@ class RRule implements RRuleInterface
 		if (! $opt['date_formatter']) {
 			if ($opt['use_intl']) {
 				$timezone = $this->dtstart->getTimezone()->getName();
-
 				if ($timezone === 'Z') {
 					$timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
 				} elseif (preg_match('/[-+]\d{2}/',$timezone)) {
@@ -2155,7 +2165,39 @@ class RRule implements RRuleInterface
 			}
 		}
 
-		$parts = array(
+        if ($opt['timeofday_formatter'] && ! is_callable($opt['timeofday_formatter'])) {
+            throw new \InvalidArgumentException('The option timeofday_formatter must callable');
+        }
+
+        if (! $opt['timeofday_formatter']) {
+            if ($opt['use_intl']) {
+                $timezone = $this->dtstart->getTimezone()->getName();
+                if ($timezone === 'Z') {
+                    $timezone = 'GMT'; // otherwise IntlDateFormatter::create fails because... reasons.
+                } elseif (preg_match('/[-+]\d{2}/',$timezone)) {
+                    $timezone = 'GMT'.$timezone; // otherwise IntlDateFormatter::create fails because... other reasons.
+                }
+                $formatter = \IntlDateFormatter::create(
+                    $opt['locale'],
+                    \IntlDateFormatter::NONE,
+                    $opt['timeofday_format'],
+                    $timezone
+                );
+                if (! $formatter) {
+                    throw new \RuntimeException('IntlDateFormatter::create() failed. Error Code: '.intl_get_error_code().' "'. intl_get_error_message().'" (this should not happen, please open a bug report!)');
+                }
+                $opt['timeofday_formatter'] = function($date) use ($formatter) {
+                    return $formatter->format($date);
+                };
+            }
+            else {
+                $opt['timeofday_formatter'] = function($date) {
+                    return $date->format('H:i:s');
+                };
+            }
+        }
+
+        $parts = array(
 			'freq' => '',
 			'byweekday' => '',
 			'bymonth' => '',
@@ -2361,6 +2403,13 @@ class RRule implements RRuleInterface
 				'%{date}' => $opt['date_formatter']($this->dtstart)
 			));
 		}
+
+        if ($opt['include_timeofday']) {
+            // from X
+            $parts['timeofday'] = strtr($i18n['timeofday'], array(
+                '%{timeofday}' => $opt['timeofday_formatter']($this->dtstart)
+            ));
+        }
 
 		// to X, or N times, or indefinitely
 		if ($opt['include_until']) {

--- a/src/i18n/de.php
+++ b/src/i18n/de.php
@@ -45,6 +45,7 @@ return array(
 	),
 	'dtstart' => ', ab dem %{date}',
     'timeofday' => ' um %{timeofday}',
+    'startingtimeofday' => ' starting at %{timeofday}',
 	'infinite' => ', für immer',
 	'until' => ', bis zum %{date}',
 	'count' => array(

--- a/src/i18n/de.php
+++ b/src/i18n/de.php
@@ -44,8 +44,8 @@ return array(
 		'else' => 'Alle %{interval} Sekunden'
 	),
 	'dtstart' => ', ab dem %{date}',
-    'timeofday' => ' um %{timeofday}',
-    'startingtimeofday' => ' starting at %{timeofday}',
+	'timeofday' => ' um %{timeofday}',
+	'startingtimeofday' => ' starting at %{timeofday}',
 	'infinite' => ', für immer',
 	'until' => ', bis zum %{date}',
 	'count' => array(

--- a/src/i18n/de.php
+++ b/src/i18n/de.php
@@ -44,8 +44,8 @@ return array(
 		'else' => 'Alle %{interval} Sekunden'
 	),
 	'dtstart' => ', ab dem %{date}',
-	'timeofday' => ' um %{timeofday}',
-	'startingtimeofday' => ' starting at %{timeofday}',
+	'timeofday' => ' um %{date}',
+	'startingtimeofday' => ' ab %{date}',
 	'infinite' => ', für immer',
 	'until' => ', bis zum %{date}',
 	'count' => array(

--- a/src/i18n/de.php
+++ b/src/i18n/de.php
@@ -44,6 +44,7 @@ return array(
 		'else' => 'Alle %{interval} Sekunden'
 	),
 	'dtstart' => ', ab dem %{date}',
+    'timeofday' => ' um %{timeofday}',
 	'infinite' => ', für immer',
 	'until' => ', bis zum %{date}',
 	'count' => array(

--- a/src/i18n/en.php
+++ b/src/i18n/en.php
@@ -46,8 +46,8 @@ return array(
 		'else' => 'every %{interval} seconds'
 	),
 	'dtstart' => ', starting from %{date}',
-    'timeofday' => ' at %{timeofday}',
-    'startingtimeofday' => ' starting at %{timeofday}',
+	'timeofday' => ' at %{timeofday}',
+	'startingtimeofday' => ' starting at %{timeofday}',
 	'infinite' => ', forever',
 	'until' => ', until %{date}',
 	'count' => array(

--- a/src/i18n/en.php
+++ b/src/i18n/en.php
@@ -47,6 +47,7 @@ return array(
 	),
 	'dtstart' => ', starting from %{date}',
     'timeofday' => ' at %{timeofday}',
+    'startingtimeofday' => ' starting at %{timeofday}',
 	'infinite' => ', forever',
 	'until' => ', until %{date}',
 	'count' => array(

--- a/src/i18n/en.php
+++ b/src/i18n/en.php
@@ -46,8 +46,8 @@ return array(
 		'else' => 'every %{interval} seconds'
 	),
 	'dtstart' => ', starting from %{date}',
-	'timeofday' => ' at %{timeofday}',
-	'startingtimeofday' => ' starting at %{timeofday}',
+	'timeofday' => ' at %{date}',
+	'startingtimeofday' => ' starting at %{date}',
 	'infinite' => ', forever',
 	'until' => ', until %{date}',
 	'count' => array(

--- a/src/i18n/en.php
+++ b/src/i18n/en.php
@@ -46,6 +46,7 @@ return array(
 		'else' => 'every %{interval} seconds'
 	),
 	'dtstart' => ', starting from %{date}',
+    'timeofday' => ' at %{timeofday}',
 	'infinite' => ', forever',
 	'until' => ', until %{date}',
 	'count' => array(

--- a/src/i18n/es.php
+++ b/src/i18n/es.php
@@ -39,8 +39,8 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', empezando desde %{date}',
-	'timeofday' => ' a las %{timeofday}',
-	'startingtimeofday' => ' empezando desde %{timeofday}',
+	'timeofday' => ' a las %{date}',
+	'startingtimeofday' => ' empezando desde %{date}',
 	'infinite' => ', por siempre',
 	'until' => ', hasta %{date}',
 	'count' => array(

--- a/src/i18n/es.php
+++ b/src/i18n/es.php
@@ -39,6 +39,7 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', empezando desde %{date}',
+    'timeofday' => ' a las %{timeofday}',
 	'infinite' => ', por siempre',
 	'until' => ', hasta %{date}',
 	'count' => array(

--- a/src/i18n/es.php
+++ b/src/i18n/es.php
@@ -40,6 +40,7 @@ return array(
 	),
 	'dtstart' => ', empezando desde %{date}',
     'timeofday' => ' a las %{timeofday}',
+    'startingtimeofday' => ' empezando desde %{timeofday}',
 	'infinite' => ', por siempre',
 	'until' => ', hasta %{date}',
 	'count' => array(

--- a/src/i18n/es.php
+++ b/src/i18n/es.php
@@ -39,8 +39,8 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', empezando desde %{date}',
-    'timeofday' => ' a las %{timeofday}',
-    'startingtimeofday' => ' empezando desde %{timeofday}',
+	'timeofday' => ' a las %{timeofday}',
+	'startingtimeofday' => ' empezando desde %{timeofday}',
 	'infinite' => ', por siempre',
 	'until' => ', hasta %{date}',
 	'count' => array(

--- a/src/i18n/fa.php
+++ b/src/i18n/fa.php
@@ -41,7 +41,8 @@ return array(
 		'1' => 'ثانیه ای',
 		'else' => 'هر %{interval} ثانیه'
 	),
-	'dtstart' => ', از %{date}',
+    'dtstart' => ', از %{date}',
+    'timeofday' => ' از %{timeofday}',
 	'infinite' => ', همیشه',
 	'until' => ', تا %{date}',
 	'count' => array(

--- a/src/i18n/fa.php
+++ b/src/i18n/fa.php
@@ -41,9 +41,9 @@ return array(
 		'1' => 'ثانیه ای',
 		'else' => 'هر %{interval} ثانیه'
 	),
-    'dtstart' => ', از %{date}',
-    'timeofday' => ' از %{timeofday}',
-    'startingtimeofday' => ' از %{timeofday}',
+	'dtstart' => ', از %{date}',
+	'timeofday' => ' از %{timeofday}',
+	'startingtimeofday' => ' از %{timeofday}',
 	'infinite' => ', همیشه',
 	'until' => ', تا %{date}',
 	'count' => array(

--- a/src/i18n/fa.php
+++ b/src/i18n/fa.php
@@ -43,6 +43,7 @@ return array(
 	),
     'dtstart' => ', از %{date}',
     'timeofday' => ' از %{timeofday}',
+    'startingtimeofday' => ' از %{timeofday}',
 	'infinite' => ', همیشه',
 	'until' => ', تا %{date}',
 	'count' => array(

--- a/src/i18n/fa.php
+++ b/src/i18n/fa.php
@@ -42,8 +42,8 @@ return array(
 		'else' => 'هر %{interval} ثانیه'
 	),
 	'dtstart' => ', از %{date}',
-	'timeofday' => ' از %{timeofday}',
-	'startingtimeofday' => ' از %{timeofday}',
+	'timeofday' => ' از %{date}',
+	'startingtimeofday' => ' از %{date}',
 	'infinite' => ', همیشه',
 	'until' => ', تا %{date}',
 	'count' => array(

--- a/src/i18n/fi.php
+++ b/src/i18n/fi.php
@@ -47,6 +47,7 @@ return array(
 	),
 	'dtstart' => ', alkaen %{date}',
     'timeofday' => ' klo %{timeofday}',
+    'startingtimeofday' => ' alkaen %{timeofday}',
 	'infinite' => ', jatkuvasti',
 	'until' => ', %{date} asti',
 	'count' => array(

--- a/src/i18n/fi.php
+++ b/src/i18n/fi.php
@@ -46,6 +46,7 @@ return array(
 		'else' => 'joka %{interval} sekunti'
 	),
 	'dtstart' => ', alkaen %{date}',
+    'timeofday' => ' klo %{timeofday}',
 	'infinite' => ', jatkuvasti',
 	'until' => ', %{date} asti',
 	'count' => array(

--- a/src/i18n/fi.php
+++ b/src/i18n/fi.php
@@ -46,8 +46,8 @@ return array(
 		'else' => 'joka %{interval} sekunti'
 	),
 	'dtstart' => ', alkaen %{date}',
-	'timeofday' => ' klo %{timeofday}',
-	'startingtimeofday' => ' alkaen %{timeofday}',
+	'timeofday' => ' klo %{date}',
+	'startingtimeofday' => ' alkaen %{date}',
 	'infinite' => ', jatkuvasti',
 	'until' => ', %{date} asti',
 	'count' => array(

--- a/src/i18n/fi.php
+++ b/src/i18n/fi.php
@@ -46,8 +46,8 @@ return array(
 		'else' => 'joka %{interval} sekunti'
 	),
 	'dtstart' => ', alkaen %{date}',
-    'timeofday' => ' klo %{timeofday}',
-    'startingtimeofday' => ' alkaen %{timeofday}',
+	'timeofday' => ' klo %{timeofday}',
+	'startingtimeofday' => ' alkaen %{timeofday}',
 	'infinite' => ', jatkuvasti',
 	'until' => ', %{date} asti',
 	'count' => array(

--- a/src/i18n/fr.php
+++ b/src/i18n/fr.php
@@ -44,8 +44,8 @@ return array(
 		'else' => 'toutes les %{interval} secondes'
 	),
 	'dtstart' => ', à partir du %{date}',
-    'timeofday' => ' à %{timeofday}',
-    'startingtimeofday' => ' à partir du %{timeofday}',
+	'timeofday' => ' à %{timeofday}',
+	'startingtimeofday' => ' à partir du %{timeofday}',
 	'infinite' => ', indéfiniment',
 	'until' => ', jusqu\'au %{date}',
 	'count' => array(

--- a/src/i18n/fr.php
+++ b/src/i18n/fr.php
@@ -44,8 +44,8 @@ return array(
 		'else' => 'toutes les %{interval} secondes'
 	),
 	'dtstart' => ', à partir du %{date}',
-	'timeofday' => ' à %{timeofday}',
-	'startingtimeofday' => ' à partir du %{timeofday}',
+	'timeofday' => ' à %{date}',
+	'startingtimeofday' => ' à partir du %{date}',
 	'infinite' => ', indéfiniment',
 	'until' => ', jusqu\'au %{date}',
 	'count' => array(

--- a/src/i18n/fr.php
+++ b/src/i18n/fr.php
@@ -45,6 +45,7 @@ return array(
 	),
 	'dtstart' => ', à partir du %{date}',
     'timeofday' => ' à %{timeofday}',
+    'startingtimeofday' => ' à partir du %{timeofday}',
 	'infinite' => ', indéfiniment',
 	'until' => ', jusqu\'au %{date}',
 	'count' => array(

--- a/src/i18n/fr.php
+++ b/src/i18n/fr.php
@@ -44,6 +44,7 @@ return array(
 		'else' => 'toutes les %{interval} secondes'
 	),
 	'dtstart' => ', à partir du %{date}',
+    'timeofday' => ' à %{timeofday}',
 	'infinite' => ', indéfiniment',
 	'until' => ', jusqu\'au %{date}',
 	'count' => array(

--- a/src/i18n/he.php
+++ b/src/i18n/he.php
@@ -41,8 +41,8 @@ return array(
 		'else' => 'כל %{interval} שניות'
 	),
 	'dtstart' => ', החל מ%{date}',
-    'timeofday' => ' החל מ%{timeofday}',
-    'startingtimeofday' => ' החל מ%{timeofday}',
+	'timeofday' => ' החל מ%{timeofday}',
+	'startingtimeofday' => ' החל מ%{timeofday}',
 	'infinite' => ', לעד',
 	'until' => ', עד %{date}',
 	'count' => array(

--- a/src/i18n/he.php
+++ b/src/i18n/he.php
@@ -42,6 +42,7 @@ return array(
 	),
 	'dtstart' => ', החל מ%{date}',
     'timeofday' => ' החל מ%{timeofday}',
+    'startingtimeofday' => ' החל מ%{timeofday}',
 	'infinite' => ', לעד',
 	'until' => ', עד %{date}',
 	'count' => array(

--- a/src/i18n/he.php
+++ b/src/i18n/he.php
@@ -41,6 +41,7 @@ return array(
 		'else' => 'כל %{interval} שניות'
 	),
 	'dtstart' => ', החל מ%{date}',
+    'timeofday' => ' החל מ%{timeofday}',
 	'infinite' => ', לעד',
 	'until' => ', עד %{date}',
 	'count' => array(

--- a/src/i18n/he.php
+++ b/src/i18n/he.php
@@ -41,8 +41,8 @@ return array(
 		'else' => 'כל %{interval} שניות'
 	),
 	'dtstart' => ', החל מ%{date}',
-	'timeofday' => ' החל מ%{timeofday}',
-	'startingtimeofday' => ' החל מ%{timeofday}',
+	'timeofday' => ' החל מ%{date}',
+	'startingtimeofday' => ' החל מ%{date}',
 	'infinite' => ', לעד',
 	'until' => ', עד %{date}',
 	'count' => array(

--- a/src/i18n/it.php
+++ b/src/i18n/it.php
@@ -39,6 +39,7 @@ return array(
 	),
 	'dtstart' => ', a partire dal %{date}',
     'timeofday' => ' alle %{timeofday}',
+    'startingtimeofday' => ' a partire dal %{timeofday}',
 	'infinite' => ', per sempre',
 	'until' => ', fino al %{date}',
 	'count' => array(

--- a/src/i18n/it.php
+++ b/src/i18n/it.php
@@ -38,8 +38,8 @@ return array(
 		'else' => 'ogni %{interval} secondi'
 	),
 	'dtstart' => ', a partire dal %{date}',
-	'timeofday' => ' alle %{timeofday}',
-	'startingtimeofday' => ' a partire dal %{timeofday}',
+	'timeofday' => ' alle %{date}',
+	'startingtimeofday' => ' a partire dal %{date}',
 	'infinite' => ', per sempre',
 	'until' => ', fino al %{date}',
 	'count' => array(

--- a/src/i18n/it.php
+++ b/src/i18n/it.php
@@ -38,6 +38,7 @@ return array(
 		'else' => 'ogni %{interval} secondi'
 	),
 	'dtstart' => ', a partire dal %{date}',
+    'timeofday' => ' alle %{timeofday}',
 	'infinite' => ', per sempre',
 	'until' => ', fino al %{date}',
 	'count' => array(

--- a/src/i18n/it.php
+++ b/src/i18n/it.php
@@ -38,8 +38,8 @@ return array(
 		'else' => 'ogni %{interval} secondi'
 	),
 	'dtstart' => ', a partire dal %{date}',
-    'timeofday' => ' alle %{timeofday}',
-    'startingtimeofday' => ' a partire dal %{timeofday}',
+	'timeofday' => ' alle %{timeofday}',
+	'startingtimeofday' => ' a partire dal %{timeofday}',
 	'infinite' => ', per sempre',
 	'until' => ', fino al %{date}',
 	'count' => array(

--- a/src/i18n/nl.php
+++ b/src/i18n/nl.php
@@ -47,6 +47,7 @@ return array(
     ),
     'dtstart' => ', wordt gestart vanaf %{date}',
     'timeofday' => ' om %{timeofday}',
+    'startingtimeofday' => ' wordt gestart vanaf %{timeofday}',
     'infinite' => ', oneindig',
     'until' => ', tot en met %{date}',
     'count' => array(

--- a/src/i18n/nl.php
+++ b/src/i18n/nl.php
@@ -46,6 +46,7 @@ return array(
         'else' => 'elke %{interval} seconden'
     ),
     'dtstart' => ', wordt gestart vanaf %{date}',
+    'timeofday' => ' om %{timeofday}',
     'infinite' => ', oneindig',
     'until' => ', tot en met %{date}',
     'count' => array(

--- a/src/i18n/nl.php
+++ b/src/i18n/nl.php
@@ -46,8 +46,8 @@ return array(
         'else' => 'elke %{interval} seconden'
     ),
     'dtstart' => ', wordt gestart vanaf %{date}',
-    'timeofday' => ' om %{timeofday}',
-    'startingtimeofday' => ' wordt gestart vanaf %{timeofday}',
+    'timeofday' => ' om %{date}',
+    'startingtimeofday' => ' wordt gestart vanaf %{date}',
     'infinite' => ', oneindig',
     'until' => ', tot en met %{date}',
     'count' => array(

--- a/src/i18n/pl.php
+++ b/src/i18n/pl.php
@@ -58,8 +58,8 @@ return array(
 		'else' => 'co %{interval} sekund'
 	),
 	'dtstart' => ', zaczynając od %{date}',
-    'timeofday' => ' o %{timeofday}',
-    'startingtimeofday' => ' zaczynając od %{timeofday}',
+	'timeofday' => ' o %{timeofday}',
+	'startingtimeofday' => ' zaczynając od %{timeofday}',
 	'infinite' => ', zawsze',
 	'until' => ', do daty %{date}',
 	'count' => array(

--- a/src/i18n/pl.php
+++ b/src/i18n/pl.php
@@ -58,6 +58,7 @@ return array(
 		'else' => 'co %{interval} sekund'
 	),
 	'dtstart' => ', zaczynając od %{date}',
+    'timeofday' => ' o %{timeofday}',
 	'infinite' => ', zawsze',
 	'until' => ', do daty %{date}',
 	'count' => array(

--- a/src/i18n/pl.php
+++ b/src/i18n/pl.php
@@ -59,6 +59,7 @@ return array(
 	),
 	'dtstart' => ', zaczynając od %{date}',
     'timeofday' => ' o %{timeofday}',
+    'startingtimeofday' => ' zaczynając od %{timeofday}',
 	'infinite' => ', zawsze',
 	'until' => ', do daty %{date}',
 	'count' => array(

--- a/src/i18n/pl.php
+++ b/src/i18n/pl.php
@@ -58,8 +58,8 @@ return array(
 		'else' => 'co %{interval} sekund'
 	),
 	'dtstart' => ', zaczynając od %{date}',
-	'timeofday' => ' o %{timeofday}',
-	'startingtimeofday' => ' zaczynając od %{timeofday}',
+	'timeofday' => ' o %{date}',
+	'startingtimeofday' => ' zaczynając od %{date}',
 	'infinite' => ', zawsze',
 	'until' => ', do daty %{date}',
 	'count' => array(

--- a/src/i18n/pt.php
+++ b/src/i18n/pt.php
@@ -39,6 +39,7 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', começando de %{date}',
+    'timeofday' => ' às %{timeofday}',
 	'infinite' => ', para sempre',
 	'until' => ', até %{date}',
 	'count' => array(

--- a/src/i18n/pt.php
+++ b/src/i18n/pt.php
@@ -40,6 +40,7 @@ return array(
 	),
 	'dtstart' => ', começando de %{date}',
     'timeofday' => ' às %{timeofday}',
+    'startingtimeofday' => ' começando de %{timeofday}',
 	'infinite' => ', para sempre',
 	'until' => ', até %{date}',
 	'count' => array(

--- a/src/i18n/pt.php
+++ b/src/i18n/pt.php
@@ -39,8 +39,8 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', começando de %{date}',
-    'timeofday' => ' às %{timeofday}',
-    'startingtimeofday' => ' começando de %{timeofday}',
+	'timeofday' => ' às %{timeofday}',
+	'startingtimeofday' => ' começando de %{timeofday}',
 	'infinite' => ', para sempre',
 	'until' => ', até %{date}',
 	'count' => array(

--- a/src/i18n/pt.php
+++ b/src/i18n/pt.php
@@ -39,8 +39,8 @@ return array(
 		'else' => 'cada %{interval} segundos'// cada 8 segundos
 	),
 	'dtstart' => ', começando de %{date}',
-	'timeofday' => ' às %{timeofday}',
-	'startingtimeofday' => ' começando de %{timeofday}',
+	'timeofday' => ' às %{date}',
+	'startingtimeofday' => ' começando de %{date}',
 	'infinite' => ', para sempre',
 	'until' => ', até %{date}',
 	'count' => array(

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -51,8 +51,8 @@ return array(
 		'else' => 'var %{interval}:e sekund'
 	),
 	'dtstart' => ', börjar %{date}',
-	'timeofday' => ' kl %{timeofday}',
-	'startingtimeofday' => ' börjar %{timeofday}',
+	'timeofday' => ' kl %{date}',
+	'startingtimeofday' => ' börjar %{date}',
 	'infinite' => ', tills vidare',
 	'until' => ', t.om %{date}',
 	'count' => array(

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -51,8 +51,8 @@ return array(
 		'else' => 'var %{interval}:e sekund'
 	),
 	'dtstart' => ', börjar %{date}',
-    'timeofday' => ' kl %{timeofday}',
-    'startingtimeofday' => ' börjar %{timeofday}',
+	'timeofday' => ' kl %{timeofday}',
+	'startingtimeofday' => ' börjar %{timeofday}',
 	'infinite' => ', tills vidare',
 	'until' => ', t.om %{date}',
 	'count' => array(

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -52,6 +52,7 @@ return array(
 	),
 	'dtstart' => ', börjar %{date}',
     'timeofday' => ' kl %{timeofday}',
+    'startingtimeofday' => ' börjar %{timeofday}',
 	'infinite' => ', tills vidare',
 	'until' => ', t.om %{date}',
 	'count' => array(

--- a/src/i18n/sv.php
+++ b/src/i18n/sv.php
@@ -51,6 +51,7 @@ return array(
 		'else' => 'var %{interval}:e sekund'
 	),
 	'dtstart' => ', börjar %{date}',
+    'timeofday' => ' kl %{timeofday}',
 	'infinite' => ', tills vidare',
 	'until' => ', t.om %{date}',
 	'count' => array(

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3192,13 +3192,13 @@ class RRuleTest extends TestCase
 				"daily"
 			),
 			array(
-				"DTSTART=20170202T161500Z\nRRULE:FREQ=MONTHLY;BYMONTHDAY=2",
+				"DTSTART:20170202T161500Z\nRRULE:FREQ=MONTHLY;BYMONTHDAY=2",
 				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
 				"monthly on the 2nd of the month at 4:15 PM",
 				"monthly on the 2nd of the month at 16:15:00"
 			),
 			array(
-				"DTSTART=20170202T063000Z\nRRULE:FREQ=HOURLY;INTERVAL=7",
+				"DTSTART:20170202T063000Z\nRRULE:FREQ=HOURLY;INTERVAL=7",
 				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
 				"every 7 hours starting at 6:30 AM",
 				"every 7 hours starting at 06:30:00"

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3193,13 +3193,13 @@ class RRuleTest extends TestCase
 			),
 			array(
 				"DTSTART:20170202T161500Z\nRRULE:FREQ=MONTHLY;BYMONTHDAY=2",
-				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+				array('locale' => "en", 'start_time_only' => true, 'explicit_infinite' => false),
 				"monthly on the 2nd of the month at 4:15 PM",
 				"monthly on the 2nd of the month at 16:15:00"
 			),
 			array(
 				"DTSTART:20170202T063000Z\nRRULE:FREQ=HOURLY;INTERVAL=7",
-				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+				array('locale' => "en", 'start_time_only' => true, 'explicit_infinite' => false),
 				"every 7 hours starting at 6:30 AM",
 				"every 7 hours starting at 06:30:00"
 			),

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3197,6 +3197,12 @@ class RRuleTest extends TestCase
                 "monthly on the 2nd of the month at 4:15 PM",
                 "monthly on the 2nd of the month at 16:15:00"
             ),
+            array(
+                "DTSTART=20170202T063000Z;RRULE:FREQ=HOURLY;INTERVAL=7",
+                array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+                "every 7 hours starting at 6:30 AM",
+                "every 7 hours starting at 06:30:00"
+            ),
 			// with custom_path
 			'custom_path' => array(
 				"DTSTART:20170202T000000Z\nRRULE:FREQ=YEARLY;UNTIL=20170205T000000Z",

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3192,13 +3192,13 @@ class RRuleTest extends TestCase
 				"daily"
 			),
 			array(
-				"DTSTART=20170202T161500Z;RRULE:FREQ=MONTHLY;BYMONTHDAY=2",
+				"DTSTART=20170202T161500Z\nRRULE:FREQ=MONTHLY;BYMONTHDAY=2",
 				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
 				"monthly on the 2nd of the month at 4:15 PM",
 				"monthly on the 2nd of the month at 16:15:00"
 			),
 			array(
-				"DTSTART=20170202T063000Z;RRULE:FREQ=HOURLY;INTERVAL=7",
+				"DTSTART=20170202T063000Z\nRRULE:FREQ=HOURLY;INTERVAL=7",
 				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
 				"every 7 hours starting at 6:30 AM",
 				"every 7 hours starting at 06:30:00"

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3191,6 +3191,12 @@ class RRuleTest extends TestCase
 				"daily",
 				"daily"
 			),
+            array(
+                "DTSTART=20170202T161500Z;RRULE:FREQ=MONTHLY;BYMONTHDAY=2",
+                array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+                "monthly on the 2nd of the month at 4:15 PM",
+                "monthly on the 2nd of the month at 16:15:00"
+            ),
 			// with custom_path
 			'custom_path' => array(
 				"DTSTART:20170202T000000Z\nRRULE:FREQ=YEARLY;UNTIL=20170205T000000Z",

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3191,18 +3191,18 @@ class RRuleTest extends TestCase
 				"daily",
 				"daily"
 			),
-            array(
-                "DTSTART=20170202T161500Z;RRULE:FREQ=MONTHLY;BYMONTHDAY=2",
-                array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
-                "monthly on the 2nd of the month at 4:15 PM",
-                "monthly on the 2nd of the month at 16:15:00"
-            ),
-            array(
-                "DTSTART=20170202T063000Z;RRULE:FREQ=HOURLY;INTERVAL=7",
-                array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
-                "every 7 hours starting at 6:30 AM",
-                "every 7 hours starting at 06:30:00"
-            ),
+			array(
+				"DTSTART=20170202T161500Z;RRULE:FREQ=MONTHLY;BYMONTHDAY=2",
+				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+				"monthly on the 2nd of the month at 4:15 PM",
+				"monthly on the 2nd of the month at 16:15:00"
+			),
+			array(
+				"DTSTART=20170202T063000Z;RRULE:FREQ=HOURLY;INTERVAL=7",
+				array('locale' => "en", 'include_timeofday' => true, 'explicit_infinite' => false),
+				"every 7 hours starting at 6:30 AM",
+				"every 7 hours starting at 06:30:00"
+			),
 			// with custom_path
 			'custom_path' => array(
 				"DTSTART:20170202T000000Z\nRRULE:FREQ=YEARLY;UNTIL=20170205T000000Z",


### PR DESCRIPTION
Create a Human Readable option for `Time of Day` that does not include the date that the rule started. This can be used as an alternate to the start date when wanting to print only the time of day for each occurrence and without the word `starting`.

Occurrences that are once per day will print the time of day
`monthly on the 2nd of the month at 4:15 PM`
Occurrences that are more than once per day will show the starting at time
`every 7 hours starting at 6:30 AM`