### PR TITLE
Omitting repetition ending date

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2092,7 +2092,8 @@ class RRule implements RRuleInterface
 			'explicit_infinite' => true,
 			'include_start' => true,
 			'include_until' => true,
-			'custom_path' => null
+			'custom_path' => null,
+			'omit_until_date' => false
 		);
 
 		// attempt to detect default locale
@@ -2369,7 +2370,7 @@ class RRule implements RRuleInterface
 					$parts['end'] = $i18n['infinite'];
 				}
 			}
-			elseif ($this->until) {
+			elseif ($this->until && !$opt['omit_until_date']) {
 				$parts['end'] = strtr($i18n['until'], array(
 					'%{date}' => $opt['date_formatter']($this->until)
 				));


### PR DESCRIPTION
Sometimes it can be useful to omit the repetition ending date if printing a human readable string, so I added this option.