### PR TITLE
Humanreadable gets monthly wrong

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -2186,6 +2186,11 @@ class RRule implements RRuleInterface
 			$parts['bymonth'] = strtr(self::i18nSelect($i18n['bymonth'], count($tmp)), array(
 				'%{months}' => self::i18nList($tmp, $i18n['and'])
 			));
+
+			if ($freq_str == 'yearly') {
+				// if a yearly frequency is being displayed by month, then switch "of the year" text to be monthly
+				$freq_str = 'monthly';
+			}
 		}
 
 		if (not_empty($this->rule['BYWEEKNO'])) {

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -3204,6 +3204,24 @@ class RRuleTest extends TestCase
 				"daily",
 				"daily"
 			),
+			array(
+				"RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=+2TU",
+				array('locale' => "en", 'include_start' => false, 'explicit_infinite' => false),
+				"yearly on the second Tuesday of the month in March",
+				"yearly on the second Tuesday of the month in March"
+			),
+			array(
+				"RRULE:FREQ=YEARLY;BYMONTH=3,6,9;BYDAY=+2TU",
+				array('locale' => "en", 'include_start' => false, 'explicit_infinite' => false),
+				"yearly on the second Tuesday of the month in March, June and September",
+				"yearly on the second Tuesday of the month in March, June and September"
+			),
+			array(
+				"RRULE:FREQ=YEARLY;BYDAY=+6WE",
+				array('locale' => "en", 'include_start' => false, 'explicit_infinite' => false),
+				"yearly on the 6th Wednesday of the year",
+				"yearly on the 6th Wednesday of the year"
+			),
 			// with custom_path
 			'custom_path' => array(
 				"DTSTART:20170202T000000Z\nRRULE:FREQ=YEARLY;UNTIL=20170205T000000Z",


### PR DESCRIPTION
This addresses Issue #116 regarding the text display `of the year` instead of `of the month` when BYMONTH is used in with a yearly frequency.
Rule `RRULE:FREQ=YEARLY;BYMONTH=3,6,9;BYDAY=+2TU` will now return `yearly on the second Tuesday of the month in March, June and September` instead of print `... of the year in March...`