### PR TITLE
correct name spacing on return type

### DIFF
--- a/src/RRuleInterface.php
+++ b/src/RRuleInterface.php
@@ -49,7 +49,7 @@ interface RRuleInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 	 * 
 	 * @param mixed $date
 	 * @param int $index The index (starts at 1)
-	 * @return DateTimeInterface|null
+	 * @return \DateTimeInterface|null
 	 */
 	public function getNthOccurrenceAfter($date, $index);
 
@@ -68,7 +68,7 @@ interface RRuleInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 	 * 
 	 * @param mixed $date
 	 * @param int $index The index (starts at 1)
-	 * @return DateTimeInterface|null
+	 * @return \DateTimeInterface|null
 	 */
 	public function getNthOccurrenceBefore($date, $index);
 
@@ -77,7 +77,7 @@ interface RRuleInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 	 * 
 	 * @param mixed $date
 	 * @param int $index 0 returns the date, positive integer returns index in the future, negative in the past
-	 * @return DateTimeInterface|null
+	 * @return \DateTimeInterface|null
 	 */
 	public function getNthOccurrenceFrom($date, $index);
 


### PR DESCRIPTION
correct name spacing on return type

phpstan interprets the namespace `RRule` and so turn the return type into `RRule\DateTimeInterface` which of course doesn't exist.