### PR TITLE
Better handle TZ with Exchange / M365 generated iCal files

### DIFF
--- a/src/RfcParser.php
+++ b/src/RfcParser.php
@@ -221,7 +221,7 @@ class RfcParser
 		foreach ($property['params'] as $name => $value) {
 			switch (strtoupper($name)) {
 				case 'TZID':
-					$tz = new \DateTimeZone($value);
+					$tz = self::parseTimeZone($value);
 				break;
 				case 'VALUE':
 					switch ($value) {
@@ -284,7 +284,7 @@ class RfcParser
 					// Ignore optional words
 					break;
 				case 'TZID':
-					$tz = new \DateTimeZone($value);
+					$tz = self::parseTimeZone($value);
 				break;
 				default:
 					throw new \InvalidArgumentException("Unknown property parameter: $name");

--- a/tests/RfcParserTest.php
+++ b/tests/RfcParserTest.php
@@ -79,6 +79,9 @@ class RfcParserTest extends TestCase
 			array('EXDATE;TZID=America/New_York:19970714T083000',
 				array(date_create('19970714T083000',new \DateTimeZone('America/New_York')))
 			),
+			array('EXDATE;TZID=W. Europe Standard Time:20230915T222222',
+				array(date_create('20230915T222222',new \DateTimeZone('Europe/Berlin')))
+			),
 		);
 	}
 


### PR DESCRIPTION
The RfcParser currently fails, if the iCal file includes Microsoft-like timezone strings (like "W. Europe Standard Time"). This is intended to use the (already available) tz parser.