### PR TITLE
Improve clarity in daily and weekly recurrence translation

### DIFF
--- a/src/i18n/es.php
+++ b/src/i18n/es.php
@@ -18,12 +18,12 @@ return array(
 	),
 	'weekly' => array(
 		'1' => 'semanal',
-		'2' => 'cualquier otra semana',
+		'2' => 'semana por medio',
 		'else' => 'cada %{interval} semanas' // cada 8 semanas
 	),
 	'daily' => array(
 		'1' => 'diario',
-		'2' => 'cualquier otro día',
+		'2' => 'día por medio',
 		'else' => 'cada %{interval} días' // cada 8 días
 	),
 	'hourly' => array(


### PR DESCRIPTION
In this MR, adjustments have been made to the translations for daily and weekly recurrences in Spanish. These changes aim to improve the clarity and understanding of the text.

For daily recurrence, the phrase "cualquier otro día" has been changed to "día por medio", and for weekly recurrence, "every other week" has been translated as "semana por medio" instead of the previous literal translation. The reason behind these changes is that literal translations from English to Spanish can be confusing and do not reflect common language usage in the context of recurrences.

These adjustments seek not only to enhance clarity but also to ensure that the translations are more natural and understandable for Spanish-speaking users.