### PR TITLE
Fix deprecation of strtoupper receiving null

### DIFF
--- a/src/RRule.php
+++ b/src/RRule.php
@@ -239,7 +239,7 @@ class RRule implements RRuleInterface
 			$this->freq = $parts['FREQ'];
 		}
 		else { // string
-			$parts['FREQ'] = strtoupper($parts['FREQ']);
+			$parts['FREQ'] = strtoupper((string) $parts['FREQ']);
 			if (! array_key_exists($parts['FREQ'], self::FREQUENCIES)) {
 				throw new \InvalidArgumentException(
 					'The FREQ rule part must be one of the following: '


### PR DESCRIPTION
This PR fixes following deprecation by moving exception throw before the call to `strtoupper`
`Deprecated: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /app/vendor/rlanvin/php-rrule/src/RRule.php on line 242`