### PR TITLE
Fix "november" typo in french translation file

### DIFF
--- a/src/i18n/fr.php
+++ b/src/i18n/fr.php
@@ -69,7 +69,7 @@ return array(
 		8 => 'août',
 		9 => 'septembre',
 		10 => 'octobre',
-		11 => 'november',
+		11 => 'novembre',
 		12 => 'décembre',
 	),
 	'byweekday' => ' le %{weekdays}',


### PR DESCRIPTION
Fix typo in french translations for human-readable recurrence patterns where "november" was used instead of "novembre".

Closes #155.