### PR TITLE
feat: add translation file support for Danish language

### DIFF
--- a/src/i18n/da.php
+++ b/src/i18n/da.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Translation file for Danish language.
+ */
+
+return array(
+	'yearly' => array(
+		'1' => 'årligt',
+		'else' => 'hver %{interval} år'
+	),
+	'monthly' => array(
+		'1' => 'månedligt',
+		'else' => 'hver %{interval} måned'
+	),
+	'weekly' => array(
+		'1' => 'ugentligt',
+		'2' => 'hver anden uge',
+		'else' => 'hver %{interval} uge'
+	),
+	'daily' => array(
+		'1' => 'dagligt',
+		'2' => 'hver anden dag',
+		'else' => 'hver %{interval} dag'
+	),
+	'hourly' => array(
+		'1' => 'hver time',
+		'else' => 'hver %{interval} time'
+	),
+	'minutely' => array(
+		'1' => 'hver minut',
+		'else' => 'hver %{interval} minut'
+	),
+	'secondly' => array(
+		'1' => 'hver sekund',
+		'else' => 'hver %{interval} sekund'
+	),
+	'dtstart' => ', begyndende fra %{date}',
+	'timeofday' => ' kl. %{date}',
+	'startingtimeofday' => ' begyndende kl. %{date}',
+	'infinite' => ', for evigt',
+	'until' => ', indtil %{date}',
+	'count' => array(
+		'1' => ', én gang',
+		'else' => ', %{count} gange'
+	),
+	'and' => 'og ',
+	'x_of_the_y' => array(
+		'yearly' => '%{x} i året',
+		'monthly' => '%{x} i måneden',
+	),
+	'bymonth' => ' i %{months}',
+	'months' => array(
+		1 => 'Januar',
+		2 => 'Februar',
+		3 => 'Marts',
+		4 => 'April',
+		5 => 'Maj',
+		6 => 'Juni',
+		7 => 'Juli',
+		8 => 'August',
+		9 => 'September',
+		10 => 'Oktober',
+		11 => 'November',
+		12 => 'December',
+	),
+	'byweekday' => ' på %{weekdays}',
+	'weekdays' => array(
+		1 => 'Mandag',
+		2 => 'Tirsdag',
+		3 => 'Onsdag',
+		4 => 'Torsdag',
+		5 => 'Fredag',
+		6 => 'Lørdag',
+		7 => 'Søndag',
+	),
+	'nth_weekday' => array(
+		'1' => 'den første %{weekday}',
+		'2' => 'den anden %{weekday}',
+		'3' => 'den tredje %{weekday}',
+		'else' => 'den %{n}. %{weekday}'
+	),
+	'-nth_weekday' => array(
+		'-1' => 'den sidste %{weekday}',
+		'-2' => 'den næstsidste %{weekday}',
+		'-3' => 'den tredjesidste %{weekday}',
+		'else' => 'den %{n}. sidste %{weekday}'
+	),
+	'byweekno' => array(
+		'1' => ' i uge %{weeks}',
+		'else' => ' i ugerne %{weeks}'
+	),
+	'nth_weekno' => '%{n}',
+	'bymonthday' => ' på %{monthdays}',
+	'nth_monthday' => array(
+		'1' => 'den 1.',
+		'2' => 'den 2.',
+		'3' => 'den 3.',
+		'21' => 'den 21.',
+		'22' => 'den 22.',
+		'23' => 'den 23.',
+		'31' => 'den 31.',
+		'else' => 'den %{n}.'
+	),
+	'-nth_monthday' => array(
+		'-1' => 'den sidste dag',
+		'-2' => 'den næstsidste dag',
+		'-3' => 'den tredjesidste dag',
+		'-21' => 'den 21. sidste dag',
+		'-22' => 'den 22. sidste dag',
+		'-23' => 'den 23. sidste dag',
+		'-31' => 'den 31. sidste dag',
+		'else' => 'den %{n}. sidste dag'
+	),
+	'byyearday' => array(
+		'1' => ' på dag %{yeardays}',
+		'else' => ' på dagene %{yeardays}'
+	),
+	'nth_yearday' => array(
+		'1' => 'den første',
+		'2' => 'den anden',
+		'3' => 'den tredje',
+		'else' => 'den %{n}.'
+	),
+	'-nth_yearday' => array(
+		'-1' => 'den sidste',
+		'-2' => 'den næstsidste',
+		'-3' => 'den tredjesidste',
+		'else' => 'den %{n}. sidste'
+	),
+	'byhour' => array(
+		'1' => ' kl. %{hours}',
+		'else' => ' kl. %{hours}'
+	),
+	'nth_hour' => '%{n}t',
+	'byminute' => array(
+		'1' => ' på minut %{minutes}',
+		'else' => ' på minutterne %{minutes}'
+	),
+	'nth_minute' => '%{n}',
+	'bysecond' => array(
+		'1' => ' på sekund %{seconds}',
+		'else' => ' på sekunderne %{seconds}'
+	),
+	'nth_second' => '%{n}',
+	'bysetpos' => ', men kun %{setpos}. forekomst af dette sæt',
+	'nth_setpos' => array(
+		'1' => 'den første',
+		'2' => 'den anden',
+		'3' => 'den tredje',
+		'else' => 'den %{n}.'
+	),
+	'-nth_setpos' => array(
+		'-1' => 'den sidste',
+		'-2' => 'den næstsidste',
+		'-3' => 'den tredjesidste',
+		'else' => 'den %{n}. sidste'
+	)
+);


### PR DESCRIPTION
### Description:
This PR adds support for the Danish (da) language by introducing a new translation file. It includes initial translations for all existing keys to ensure consistency with other supported languages.

### Changes:

Added `da.php` to the i18n directory

Included base translations based on English